### PR TITLE
Regex for parsing, support inline comments, support `key value` format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 2.1.0
+- **Feature**: Added support for `key value` mapping in env vars file
+- **Feature**: Added support for inline comments `ENV=VALUE # inline comment`
+- **Change**: Will now ignore invalid lines in env vars file instead of throwing an error
+- **Change**: Migrated all the parsing over to regex since the file format is simple enough right
+now to support that
+- **Bug**: Removed old test cases for the `-e/--env` flags that were not needed anymore
+
 ## 2.0.0
 - ***BREAKING***: Removed the `-e` and `--env` flags. Now it just expects the first arg to `env-cmd` to be the relative path to the env file: `env-cmd env_file command carg1 carg2`
 - **Change:** `ParseEnvFile` is now more properly named `ParseEnvString`

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![npm](https://img.shields.io/npm/l/env-cmd.svg?maxAge=2592000)](https://www.npmjs.com/package/env-cmd)
 
 # env-cmd
-A simple node program for executing commands using an environment from an env file
+A simple node program for executing commands using an environment from an env file.
 
 ## Install
 `npm install env-cmd`
@@ -14,14 +14,13 @@ A simple node program for executing commands using an environment from an env fi
 **Environment file `./test/.env`**
 ```
 # This is a comment
-ENV1=THANKS
-ENV2=FORALL
-ENV4=THEFISH
+ENV1=THANKS # Yay inline comments support
+ENV2=FOR ALL
+ENV3 THE FISH # This format is also accepted
 ```
-*This is the only accepted format for an environment file. If other formats are desired please create an issue*
 
 **Package.json**
-```js
+```json
 {
   "scripts": {
     "test": "env-cmd ./test/.env mocha -R spec"
@@ -35,11 +34,17 @@ or
 ./node_modules/.bin/env-cmd ./test/.env node index.js
 ```
 
+## Environment File Formats
+
+These are the currently accepted environment file formats. If any other formats are desired please create an issue.
+- `key=value`
+- `key value`
+
 ## Why
 
 Because sometimes its just too cumbersome passing lots of environment variables to scripts. Its usually just easier to have a file with all the vars in them, especially for development and testing.
 
-**Do not commit sensitive env data to a public git repo!**
+**Do not commit sensitive environment data to a public git repo!**
 
 ## Related Projects
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -58,37 +58,39 @@ function ParseArgs (args) {
   }
 }
 
-function ParseEnvString (envFileString) {
-  const envs = Object.assign({}, process.env)
-  while (envFileString.length) {
-    // The the last index of the line using the newline delimiter
-    let endOfLineIndex = envFileString.indexOf('\n')
+function StripComments (envString) {
+  const commentsRegex = /[ ]*(#.*$)/gim
+  return envString.replace(commentsRegex, '')
+}
 
-    // If no newline, then assume end of file
-    if (endOfLineIndex === -1) {
-      endOfLineIndex = envFileString.length
-    }
+function StripEmptyLines (envString) {
+  const emptyLinesRegex = /(^\n)/gim
+  return envString.replace(emptyLinesRegex, '')
+}
 
-    // Get the full line
-    const line = envFileString.slice(0, endOfLineIndex + 1)
-
-    // Shrink the file by 1 line
-    envFileString = envFileString.slice(line.length)
-
-    // Only parse lines that are not empty and don't begin with #
-    if (line.length > 1 && line[0] !== '#') {
-      // Parse the line
-      const equalSign = line.indexOf('=')
-
-      if (equalSign === -1) {
-        throw new Error('Error! Malformed line in env file.')
-      }
-
-      // Set then new env var
-      envs[line.slice(0, equalSign)] = line.slice(equalSign + 1, endOfLineIndex)
-    }
+function ParseEnvVars (envString) {
+  const envParseRegex = /^((.+?)[ =](.*))$/gim
+  const matches = {}
+  let match
+  while ((match = envParseRegex.exec(envString)) !== null) {
+    // Note: match[1] is the full env=var line
+    matches[match[2]] = match[3]
   }
-  return envs
+  return matches
+}
+
+function ParseEnvString (envFileString) {
+  // First thing we do is stripe out all comments
+  envFileString = StripComments(envFileString)
+
+  // Next we stripe out all the empty lines
+  envFileString = StripEmptyLines(envFileString)
+
+  // Parse the envs vars out
+  const envs = ParseEnvVars(envFileString)
+
+  // Merge the file env vars with the current process env vars (the file vars overwrite process vars)
+  return Object.assign({}, process.env, envs)
 }
 
 function PrintHelp () {
@@ -114,5 +116,8 @@ module.exports = {
   ParseArgs,
   ParseEnvString,
   PrintHelp,
-  HandleUncaughtExceptions
+  HandleUncaughtExceptions,
+  StripComments,
+  StripEmptyLines,
+  ParseEnvVars
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "env-cmd",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Executes a command using the envs in the provided env file",
   "main": "lib/index.js",
   "bin": {


### PR DESCRIPTION
- Moved over to using regex for parsing the env file
- Added support for inline comments
- Added support for `key value` pairing file format
- Will now ignore invalid lines in env file, instead of throwing an error
- Removed old test cases
- Added more specific test cases