### PR TITLE
Add support for JSON format

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,3 +54,7 @@ Because sometimes its just too cumbersome passing lots of environment variables 
 ## Special Thanks
 
 Special thanks to [`cross-env`](https://github.com/kentcdodds/cross-env) for inspiration (use's the same `cross-spawn` lib underneath too).
+
+## Contributors
+
+- Eric Lanehart

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ or
 These are the currently accepted environment file formats. If any other formats are desired please create an issue.
 - `key=value`
 - `key value`
+- Key/value pairs as JSON
 
 ## Why
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -17,7 +17,9 @@ function EnvCmd (args) {
   }
 
   // Parse the env file string
-  const env = ParseEnvString(file)
+  const env = path.extname(parsedArgs.envFilePath).toLowerCase() === '.json'
+    ? Object.assign({}, process.env, require(parsedArgs.envFilePath))
+    : ParseEnvString(file)
 
   // Execute the command with the given environment variables
   if (parsedArgs.command) {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,9 @@
     "run"
   ],
   "author": "Todd Bluhm",
+  "contributors": [
+    "Eric Lanehart <eric@pushred.co>"
+  ],
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/toddbluhm/env-cmd/issues"


### PR DESCRIPTION
Hello!

I came across env-cmd when trying to hunt down a module that could source env vars from a JSON file _to the environment_ rather than merging them into `process.env` within a module as [dotenv][dotenv] and a few others do.

The impetus for this was [Apex][apex] which frustratingly only supports JSON files. It's an opinion that has some merit though on reflection. JSON dodges the crossplatform issues these files tend to have both in their content and sourcing methods. Thought this dovetailed with the goals of cross-env and env-cmd and went ahead and implemented it since it requires only some short-circuit logic.

[dotenv]: https://github.com/motdotla/dotenv
[apex]: http://apex.run/
