### PR TITLE
Fix bug when including a # in the env value

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ A simple node program for executing commands using an environment from an env fi
 ENV1=THANKS # Yay inline comments support
 ENV2=FOR ALL
 ENV3 THE FISH # This format is also accepted
+
+# Surround value in double quotes when using a # symbol in the value
+ENV4="ValueContains#Symbol"
+
+# If using double quotes as part of the value, you must surround the value in double quotes
+ENV5=""Value includes double quotes""
 ```
 
 **Package.json**

--- a/lib/index.js
+++ b/lib/index.js
@@ -52,14 +52,32 @@ function ParseArgs (args) {
 
 // Strips out comments from env file string
 function StripComments (envString) {
-  const commentsRegex = /[ ]*(#.*$)/gim
-  return envString.replace(commentsRegex, '')
+  const commentsRegex = /("{1}.*"{1})*?([ ]*#.*$)/gim
+  let match = commentsRegex.exec(envString)
+  let newString = envString
+  while (match != null) {
+    newString = newString.replace(match[2], '')
+    match = commentsRegex.exec(envString)
+  }
+  return newString
 }
 
 // Strips out newlines from env file string
 function StripEmptyLines (envString) {
   const emptyLinesRegex = /(^\n)/gim
   return envString.replace(emptyLinesRegex, '')
+}
+
+// Stripes out double quotes to allow for usage for special # in values
+function StripDoubleQuotes (envString) {
+  const doubleQuotesRegex = /"{1}(.*)"{1}/gim
+  let match = doubleQuotesRegex.exec(envString)
+  let newString = envString
+  while (match != null) {
+    newString = newString.replace(match[0], match[1])
+    match = doubleQuotesRegex.exec(envString)
+  }
+  return newString
 }
 
 // Parse out all env vars from an env file string
@@ -81,6 +99,9 @@ function ParseEnvString (envFileString) {
 
   // Next we stripe out all the empty lines
   envFileString = StripEmptyLines(envFileString)
+
+  // Finally we stripe out all the double quotes for special charactes
+  envFileString = StripDoubleQuotes(envFileString)
 
   // Parse the envs vars out
   const envs = ParseEnvVars(envFileString)
@@ -153,6 +174,7 @@ module.exports = {
   HandleUncaughtExceptions,
   StripComments,
   StripEmptyLines,
+  StripDoubleQuotes,
   ParseEnvVars,
   ParseRCFile,
   UseRCFile,

--- a/test/test.js
+++ b/test/test.js
@@ -40,6 +40,7 @@ const PrintHelp = lib.PrintHelp
 const HandleUncaughtExceptions = lib.HandleUncaughtExceptions
 const StripComments = lib.StripComments
 const StripEmptyLines = lib.StripEmptyLines
+const StripDoubleQuotes = lib.StripDoubleQuotes
 const ParseEnvVars = lib.ParseEnvVars
 
 describe('env-cmd', function () {
@@ -94,12 +95,24 @@ describe('env-cmd', function () {
       const envString = StripComments('BOB=COOL#inline1\nNODE_ENV=dev #cool\nANSWER=42 AND COUNTING  #multiple-spaces\n')
       assert(envString === 'BOB=COOL\nNODE_ENV=dev\nANSWER=42 AND COUNTING\n')
     })
+
+    it('should not strip out values that are surrouned in double quotes', function () {
+      const envString = StripComments('BOB="#COOL"#inline1\nNODE_ENV=dev #cool\nANSWER="#42 AND COUNTING"  #multiple-spaces\n')
+      assert(envString === 'BOB="#COOL"\nNODE_ENV=dev\nANSWER="#42 AND COUNTING"\n')
+    })
   })
 
   describe('StripEmptyLines', function () {
     it('should strip out all empty lines', function () {
       const envString = StripEmptyLines('\nBOB=COOL\n\nNODE_ENV=dev\n\nANSWER=42 AND COUNTING\n\n')
       assert(envString === 'BOB=COOL\nNODE_ENV=dev\nANSWER=42 AND COUNTING\n')
+    })
+  })
+
+  describe('StripDoubleQuotes', function () {
+    it('should strip out single double quotes', function () {
+      const envString = StripDoubleQuotes(`BOB="#COOL"\nNODE_ENV=dev\nANSWER="42 AND #COUNTING"\nCOOL=""quoted""\nAwesome="'singles'"`)
+      assert(envString === `BOB=#COOL\nNODE_ENV=dev\nANSWER=42 AND #COUNTING\nCOOL="quoted"\nAwesome='singles'`)
     })
   })
 


### PR DESCRIPTION
Fixes for #12 

- Fixed a bug that caused a # symbol in the env value to be interpreted
as an inline comment
- When you want to include a # in you value, you need to wrap it in
double quotes: ENV=“some#symbol value”