### PR TITLE
Add system env vars back into the env list

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -10,7 +10,10 @@ function EnvCmd (args) {
   const parsedArgs = ParseArgs(args)
 
   // If a .rc file was found then use that
-  const env = fs.existsSync(rcFileLocation) ? UseRCFile(parsedArgs) : UseCmdLine(parsedArgs)
+  let env = fs.existsSync(rcFileLocation) ? UseRCFile(parsedArgs) : UseCmdLine(parsedArgs)
+
+  // Add in the system environment variables to our environment list
+  env = Object.assign({}, process.env, env)
 
   // Execute the command with the given environment variables
   const proc = spawn(parsedArgs.command, parsedArgs.commandArgs, {
@@ -117,7 +120,7 @@ function UseCmdLine (parsedArgs) {
 
   // Parse the env file string using the correct parser
   const env = ext === '.json' || ext === '.js'
-    ? Object.assign({}, process.env, require(envFilePath))
+    ? require(envFilePath)
     : ParseEnvString(file)
 
   return env


### PR DESCRIPTION
Fixes issue #13 

- After retrieving user set envs from a file, add the system envs back
into the envs object so that envs like PATH, etc… will exist for the
spawned command