### PR TITLE
ADD default .env file as a fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ A simple node program for executing commands using an environment from an env fi
 
 ### Environment File Usage
 
+If the specified environment file can't be found, an error message is logged.  
+If then `.env` fallback file can't be found too, an error is thrown.
+
 **Environment file `./test/.env`**
 ```
 # This is a comment
@@ -28,8 +31,18 @@ ENV4="ValueContains#Symbol"
 # If using double quotes as part of the value, you must surround the value in double quotes
 ENV5=""Value includes double quotes""
 ```
+**Fallback Environment file `./.env`**
+```
+# This can be used as an example fallback
+ENV1=foo
+ENV2=bar
+ENV3=baz
+ENV4=quux
+ENV5=gorge
+```
 
 **Package.json**
+to use `./test/.env`
 ```json
 {
   "scripts": {
@@ -37,12 +50,25 @@ ENV5=""Value includes double quotes""
   }
 }
 ```
+
+uses `./.env` as a fallback
+```json
+{
+  "scripts": {
+    "test": "env-cmd ./test/.doesntExist mocha -R spec"
+  }
+}
+```
 or
 
 **Terminal**
 ```sh
+# uses ./test/.env
 ./node_modules/.bin/env-cmd ./test/.env node index.js
+# uses ./.env as a fallback, because i can't find `./test/.myEnv`
+./node_modules/.bin/env-cmd ./test/.myEnv node index.js
 ```
+
 
 ### .rc file usage
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,7 +4,8 @@ const spawn = require('cross-spawn').spawn
 const path = require('path')
 const fs = require('fs')
 const rcFileLocation = path.join(process.cwd(), '.env-cmdrc')
-
+const envFilePathDefault = path.join(process.cwd(), '.env')
+  
 function EnvCmd (args) {
   // First Parse the args from the command line
   const parsedArgs = ParseArgs(args)
@@ -133,8 +134,13 @@ function UseCmdLine (parsedArgs) {
   let file
   try {
     file = fs.readFileSync(envFilePath, { encoding: 'utf8' })
-  } catch (e) {
-    throw new Error(`Error! Could not find or read file at ${envFilePath}`)
+  } catch (err) {
+    console.error(`Error! Could not find or read file at ${envFilePath}`)
+    try {
+      file = fs.readFileSync(envFilePathDefault)
+    } catch (e) {
+      throw new Error(`Error! Could not fallback to find or read file at ${envFilePathDefault}`)
+    }
   }
 
   const ext = path.extname(envFilePath).toLowerCase()

--- a/lib/index.js
+++ b/lib/index.js
@@ -5,7 +5,7 @@ const path = require('path')
 const fs = require('fs')
 const rcFileLocation = path.join(process.cwd(), '.env-cmdrc')
 const envFilePathDefault = path.join(process.cwd(), '.env')
-  
+
 function EnvCmd (args) {
   // First Parse the args from the command line
   const parsedArgs = ParseArgs(args)
@@ -99,7 +99,7 @@ function ParseEnvVars (envString) {
 // Parse out all env vars from a given env file string and return an object
 function ParseEnvString (envFileString) {
   // First thing we do is stripe out all comments
-  envFileString = StripComments(envFileString)
+  envFileString = StripComments(envFileString.toString())
 
   // Next we stripe out all the empty lines
   envFileString = StripEmptyLines(envFileString)
@@ -135,7 +135,12 @@ function UseCmdLine (parsedArgs) {
   try {
     file = fs.readFileSync(envFilePath, { encoding: 'utf8' })
   } catch (err) {
-    console.error(`Error! Could not find or read file at ${envFilePath}`)
+    console.error(`WARNING:
+      Could not find or read file at:
+        ${envFilePath}
+      Trying to fallback to read:
+        ${envFilePathDefault}
+    `)
     try {
       file = fs.readFileSync(envFilePathDefault)
     } catch (e) {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
   "author": "Todd Bluhm",
   "contributors": [
     "Eric Lanehart <eric@pushred.co>",
-    "Jon Scheiding <jonscheiding@gmail.com>"
+    "Jon Scheiding <jonscheiding@gmail.com>",
+    "serapath (Alexander Praetorius) <dev@serapath.de>"
   ],
   "license": "MIT",
   "bugs": {

--- a/test/test.js
+++ b/test/test.js
@@ -250,13 +250,14 @@ describe('env-cmd', function () {
       assert(spawnStub.args[0][2].env.ANSWER === '42')
     })
 
-    it('should throw error if file does not exist', function () {
+    it('should throw error if file and fallback does not exist', function () {
       this.readFileStub.restore()
+
       try {
         EnvCmd(['./test/.non-existent-file', 'echo', '$BOB'])
       } catch (e) {
-        const resolvedPath = path.join(process.cwd(), 'test/.non-existent-file')
-        assert(e.message === `Error! Could not find or read file at ${resolvedPath}`)
+        const resolvedPath = path.join(process.cwd(), '.env')
+        assert(e.message ===`Error! Could not fallback to find or read file at ${resolvedPath}`)
         return
       }
       assert(!'No exception thrown')


### PR DESCRIPTION
If a repository contains a `.env` example file or - in case of a private repository - a `.env` file with production values, a developer can add a local (e.g. `.env.local` file to `.gitignore`) and feed it to `env-cmd`.
So in development a custom local configuration can be used, but in production, `env-cmd` falls back to `.env`

I added the implementation, added tests and updated the readme to explain what it does.
If multiple people work on a project or dev environment is different from production,
this turned out to be an amazingly useful feature to me.

It is inspired by [localenv](https://www.npmjs.com/package/localenv)

If this feature is not welcome - I'm ok with that and would then publish it as a separate module :-)
