### PR TITLE
add —no-override option

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,14 @@ For more complex projects, a `.env-cmdrc` file can be defined in the root direct
 ```sh
 ./node_modules/.bin/env-cmd production node index.js
 ```
+### --no-override option
 
+Sometimes you want to set env variable which is set in a file without changing env file.
+
+**Terminal**
+```sh
+ENV1=welcome ./node_modules/.bin/env-cmd --no-override ./test/.env node index.js
+```
 ## Environment File Formats
 
 These are the currently accepted environment file formats. If any other formats are desired please create an issue.

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ For more complex projects, a `.env-cmdrc` file can be defined in the root direct
 ```
 ### --no-override option
 
-Sometimes you want to set env variable which is set in a file without changing env file.
+Sometimes you want to set env variables from a file without overriding existing process env vars.
 
 **Terminal**
 ```sh

--- a/lib/index.js
+++ b/lib/index.js
@@ -14,7 +14,12 @@ function EnvCmd (args) {
   let env = fs.existsSync(rcFileLocation) ? UseRCFile(parsedArgs) : UseCmdLine(parsedArgs)
 
   // Add in the system environment variables to our environment list
-  env = Object.assign({}, process.env, env)
+
+  if (parsedArgs.noOverride) {
+    env = Object.assign({}, env, process.env)
+  } else {
+    env = Object.assign({}, process.env, env)
+  }
 
   // Execute the command with the given environment variables
   const proc = spawn(parsedArgs.command, parsedArgs.commandArgs, {
@@ -34,10 +39,14 @@ function ParseArgs (args) {
 
   let envFile
   let command
+  let noOverride
   let commandArgs = args.slice()
   while (commandArgs.length) {
     const arg = commandArgs.shift()
-
+    if (arg === '--no-override') {
+      noOverride = true
+      continue
+    }
     // assume the first arg is the env file (or if using .rc the environment name)
     if (!envFile) {
       envFile = arg
@@ -50,7 +59,8 @@ function ParseArgs (args) {
   return {
     envFile,
     command,
-    commandArgs
+    commandArgs,
+    noOverride
   }
 }
 
@@ -160,12 +170,15 @@ function UseCmdLine (parsedArgs) {
 // Prints out some minor help text
 function PrintHelp () {
   return `
-Usage: env-cmd [env_file | env_name] command [command options]
+Usage: env-cmd [option] [env_file | env_name] command [command options]
 
 A simple utility for running a cli application using an env config file.
 
 Also supports using a .env-cmdrc json file in the execution directory to support multiple
 environment configs in one file.
+
+Options:
+  --no-override - if you do not wath shell envs to be overrided by env_file
   `
 }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -11,14 +11,14 @@ function EnvCmd (args) {
   const parsedArgs = ParseArgs(args)
 
   // If a .rc file was found then use that
-  let env = fs.existsSync(rcFileLocation) ? UseRCFile(parsedArgs) : UseCmdLine(parsedArgs)
+  let parsedEnv = fs.existsSync(rcFileLocation) ? UseRCFile(parsedArgs) : UseCmdLine(parsedArgs)
 
   // Add in the system environment variables to our environment list
+  let env = Object.assign({}, process.env, parsedEnv)
 
+  // Override the merge order if --no-override flag set
   if (parsedArgs.noOverride) {
-    env = Object.assign({}, env, process.env)
-  } else {
-    env = Object.assign({}, process.env, env)
+    env = Object.assign({}, parsedEnv, process.env)
   }
 
   // Execute the command with the given environment variables
@@ -178,7 +178,7 @@ Also supports using a .env-cmdrc json file in the execution directory to support
 environment configs in one file.
 
 Options:
-  --no-override - if you do not wath shell envs to be overrided by env_file
+  --no-override - do not override existing process env vars with file env vars
   `
 }
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
   "contributors": [
     "Eric Lanehart <eric@pushred.co>",
     "Jon Scheiding <jonscheiding@gmail.com>",
-    "serapath (Alexander Praetorius) <dev@serapath.de>"
+    "serapath (Alexander Praetorius) <dev@serapath.de>",
+    "Anton Versal <ant.ver@gmail.com>"
   ],
   "license": "MIT",
   "bugs": {

--- a/test/test.js
+++ b/test/test.js
@@ -44,6 +44,11 @@ const ParseEnvVars = lib.ParseEnvVars
 
 describe('env-cmd', function () {
   describe('ParseArgs', function () {
+    it('should parse out --no-override option ', function () {
+      const parsedArgs = ParseArgs(['--no-override', './test/envFile', 'command', 'cmda1', 'cmda2'])
+      assert(parsedArgs.noOverride === true)
+    })
+
     it('should parse out the envfile', function () {
       const parsedArgs = ParseArgs(['./test/envFile', 'command', 'cmda1', 'cmda2'])
       assert(parsedArgs.envFile === './test/envFile')
@@ -226,6 +231,19 @@ describe('env-cmd', function () {
       assert(spawnStub.args[0][1][0] === '$BOB')
       assert(spawnStub.args[0][2].env.BOB === 'COOL')
       assert(spawnStub.args[0][2].env.NODE_ENV === 'dev')
+      assert(spawnStub.args[0][2].env.ANSWER === '42')
+    })
+
+    it('should spawn a new process without overriding shell env vars', function () {
+      process.env.NODE_ENV = 'development'
+      process.env.BOB = 'SUPERCOOL'
+      this.readFileStub.returns('BOB=COOL\nNODE_ENV=dev\nANSWER=42\n')
+      EnvCmd(['--no-override', './test/.env', 'echo', '$BOB'])
+      assert(this.readFileStub.args[0][0] === path.join(process.cwd(), 'test/.env'))
+      assert(spawnStub.args[0][0] === 'echo')
+      assert(spawnStub.args[0][1][0] === '$BOB')
+      assert(spawnStub.args[0][2].env.BOB === 'SUPERCOOL')
+      assert(spawnStub.args[0][2].env.NODE_ENV === 'development')
       assert(spawnStub.args[0][2].env.ANSWER === '42')
     })
 


### PR DESCRIPTION
Sometimes it's required to not override env variables by file and just fill envs which are not set.