### PR TITLE
Allow for using absolute pathing, ~ pathing, and relative pathing

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,21 @@ These are the currently accepted environment file formats. If any other formats 
 - JavaScript file exporting an object
 - `.env-cmdrc` file (as valid json) in execution directory
 
+## Path Rules
+
+This lib attempts to follow standard `bash` path rules. The rules are as followed:
+
+Home Directory = `/Users/test`
+
+Working Directory = `/Users/test/Development/app`
+
+| Type | Input Path | Expanded Path |
+| -- | -- | ------------- |
+| Absolute | `/some/absolute/path.env` | `/some/absolute/path.env` |
+| Home Directory with `~` | `~/starts/on/homedir/path.env` | `/Users/test/starts/on/homedir/path.env` |
+| Relative | `./some/relative/path.env` or `some/relative/path.env` | `/Users/test/Development/app/some/relative/path.env` |
+| Relative with parent dir | `../some/relative/path.env` | `/Users/test/Development/some/relative/path.env` |
+
 ## Why
 
 Because sometimes its just too cumbersome passing lots of environment variables to scripts. Its usually just easier to have a file with all the vars in them, especially for development and testing.

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,6 +3,7 @@
 const spawn = require('cross-spawn').spawn
 const path = require('path')
 const fs = require('fs')
+const os = require('os')
 const rcFileLocation = path.join(process.cwd(), '.env-cmdrc')
 const envFilePathDefault = path.join(process.cwd(), '.env')
 
@@ -209,7 +210,7 @@ function UseRCFile (options) {
  * @return      {Object}  Key/Value pairing of env vars found in .env file
  */
 function UseCmdLine (options) {
-  const envFilePath = path.join(process.cwd(), options.envFile)
+  const envFilePath = ResolveEnvFilePath(options.envFile)
 
   // Attempt to open the provided file
   let file
@@ -272,6 +273,20 @@ function HandleUncaughtExceptions (e) {
   process.exit(1)
 }
 
+/**
+ * A simple function for resolving the path the user entered
+ * @param       {String} userPath A path
+ * @return      {String} The fully qualified absolute path
+ */
+function ResolveEnvFilePath (userPath) {
+  // Make sure a home directory exist
+  const home = os.homedir()
+  if (home) {
+    userPath = userPath.replace(/^~($|\/|\\)/, `${home}$1`)
+  }
+  return path.resolve(process.cwd(), userPath)
+}
+
 process.on('uncaughtException', HandleUncaughtExceptions)
 
 module.exports = {
@@ -285,5 +300,6 @@ module.exports = {
   ParseEnvVars,
   ParseRCFile,
   UseRCFile,
-  UseCmdLine
+  UseCmdLine,
+  ResolveEnvFilePath
 }

--- a/test/test.js
+++ b/test/test.js
@@ -375,6 +375,14 @@ describe('env-cmd', function () {
       const abPath = ResolveEnvFilePath('fish.env')
       assert(abPath === '/Users/hitchhikers-guide-to-the-galaxy/Thanks/fish.env')
     })
+    it('should add "./fish.env" to the end of the current directory', function () {
+      const abPath = ResolveEnvFilePath('./fish.env')
+      assert(abPath === '/Users/hitchhikers-guide-to-the-galaxy/Thanks/fish.env')
+    })
+    it('should add "../fish.env" to the end of the current directory', function () {
+      const abPath = ResolveEnvFilePath('../fish.env')
+      assert(abPath === '/Users/hitchhikers-guide-to-the-galaxy/fish.env')
+    })
     it('should add "for-all-the/fish.env" to the end of the current directory', function () {
       const abPath = ResolveEnvFilePath('for-all-the/fish.env')
       assert(abPath === '/Users/hitchhikers-guide-to-the-galaxy/Thanks/for-all-the/fish.env')


### PR DESCRIPTION
***Breaking Change***: This changes how env file pathing works.

This PR enables the use of absolute pathing and pathing using the `~` character.

- Absolute pathing (starts with a `/`): `/some/absolute/path.env`
- Pathing using `~`: `~/starts/on/home/path.env`
- Relative pathing (starts with NO `/`): `some/relative/path.env`
or `./some/relative/path.env`
- Relative pathing and parent dirs: `../some/relative/path/one/level/up.env`

Resolves: https://github.com/toddbluhm/env-cmd/issues/29