### PR TITLE
Add support for escaping double and single quoted values.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -129,7 +129,13 @@ function ParseEnvVars (envString) {
   let match
   while ((match = envParseRegex.exec(envString)) !== null) {
     // Note: match[1] is the full env=var line
-    matches[match[2]] = match[3]
+    const key = match[2]
+    let value = match[3] || ''
+
+    // remove any surrounding quotes
+    value = value.replace(/(^['"]|['"]$)/g, '')
+
+    matches[key] = value
   }
   return matches
 }

--- a/test/test.js
+++ b/test/test.js
@@ -126,6 +126,21 @@ describe('env-cmd', function () {
       assert(envVars.BOB === 'COOL')
       assert(envVars.ANSWER === '42 AND COUNTING')
     })
+
+    it('should default an empty value to an empty string', function () {
+      const envVars = ParseEnvVars('EMPTY=\n')
+      assert(envVars.EMPTY === '')
+    })
+
+    it('should escape double quoted values', function () {
+      const envVars = ParseEnvVars('DOUBLE_QUOTES="double_quotes"\n')
+      assert(envVars.DOUBLE_QUOTES === 'double_quotes')
+    })
+
+    it('should escape single quoted values', function () {
+      const envVars = ParseEnvVars('SINGLE_QUOTES=\'single_quotes\'\n')
+      assert(envVars.SINGLE_QUOTES === 'single_quotes')
+    })
   })
 
   describe('JSON and JS format support', function () {

--- a/test/test.js
+++ b/test/test.js
@@ -141,6 +141,20 @@ describe('env-cmd', function () {
       const envVars = ParseEnvVars('SINGLE_QUOTES=\'single_quotes\'\n')
       assert(envVars.SINGLE_QUOTES === 'single_quotes')
     })
+
+    it('should preserve embedded double quotes', function () {
+      const envVars = ParseEnvVars('DOUBLE=""""\nDOUBLE_ONE=\'"double_one"\'\nDOUBLE_TWO=""double_two""\n')
+      assert(envVars.DOUBLE === '""')
+      assert(envVars.DOUBLE_ONE === '"double_one"')
+      assert(envVars.DOUBLE_TWO === '"double_two"')
+    })
+
+    it('should preserve embedded single quotes', function () {
+      const envVars = ParseEnvVars('SINGLE=\'\'\'\'\nSINGLE_ONE=\'\'single_one\'\'\nSINGLE_TWO="\'single_two\'"\n')
+      assert(envVars.SINGLE === '\'\'')
+      assert(envVars.SINGLE_ONE === '\'single_one\'')
+      assert(envVars.SINGLE_TWO === '\'single_two\'')
+    })
   })
 
   describe('JSON and JS format support', function () {


### PR DESCRIPTION
This feature borrows a few lines of code from [dotenv](https://github.com/motdotla/dotenv) to add support for escaping double and single quoted values. This is closer to the behavior of the shell which escapes quoted values assigned to variables.

On one of my projects, I need to specify an environment variable as a JSON string, which would break when quoted (quotes are also required to source the `.env` file in the shell). With this patch, the quoted variable now has the same value when sourced in the shell or loaded with env-cmd.