### PR TITLE
Stripe spaces out around equal sign when parsing an env file.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 8.0.0 - In Development
+- ***BREAKING***: Spaces around the `=` in env files are now striped out. In order to include a beginning space in an env var value, you need to surround the value in double or single quotes. `ENV = " Value"`
+
 ## 7.0.0
 - ***BREAKING***: The `.env` file path resolving has been changed to allow for absolute pathing, relative pathing, and `~` home directory pathing. Please
 see Readme.md for more info about how the new pathing conventions work.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## 8.0.0 - In Development
-- ***BREAKING***: Spaces around the `=` in env files are now striped out. In order to include a beginning space in an env var value, you need to surround the value in double or single quotes. `ENV = " Value"`
+- ***BREAKING***: Stripe out spaces around the `key` and `value` in an env file. In order to include a beginning/ending space in an env var value, you need to surround the value in double or single quotes. `ENV = " Value"`
 
 ## 7.0.0
 - ***BREAKING***: The `.env` file path resolving has been changed to allow for absolute pathing, relative pathing, and `~` home directory pathing. Please

--- a/lib/index.js
+++ b/lib/index.js
@@ -129,8 +129,8 @@ function ParseEnvVars (envString) {
   let match
   while ((match = envParseRegex.exec(envString)) !== null) {
     // Note: match[1] is the full env=var line
-    const key = match[2]
-    let value = match[3] || ''
+    const key = match[2].trim()
+    let value = match[3].trim() || ''
 
     // remove any surrounding quotes
     value = value.replace(/(^['"]|['"]$)/g, '')

--- a/test/test.js
+++ b/test/test.js
@@ -155,6 +155,20 @@ describe('env-cmd', function () {
       assert(envVars.SINGLE_ONE === '\'single_one\'')
       assert(envVars.SINGLE_TWO === '\'single_two\'')
     })
+
+    it('should parse out all env vars ignoring spaces around = sign', function () {
+      const envVars = ParseEnvVars('BOB = COOL\nNODE_ENV =dev\nANSWER= 42 AND COUNTING')
+      assert(envVars.BOB === 'COOL')
+      assert(envVars.NODE_ENV === 'dev')
+      assert(envVars.ANSWER === '42 AND COUNTING')
+    })
+
+    it('should parse out all env vars ignoring spaces around = sign', function () {
+      const envVars = ParseEnvVars('BOB = "COOL "\nNODE_ENV = dev\nANSWER= \' 42 AND COUNTING\'')
+      assert(envVars.BOB === 'COOL ')
+      assert(envVars.NODE_ENV === 'dev')
+      assert(envVars.ANSWER === ' 42 AND COUNTING')
+    })
   })
 
   describe('JSON and JS format support', function () {


### PR DESCRIPTION
When parsing an env var file, we need to stripe out the spaces around the `key` and `value` so as to allow a broader range of formatting and better compatibility with other env programs.

`ENV = VALUE` - result is now just `VALUE`
`ENV = " Value"` - result is now ` Value` (space in front)
 
Fixes issue: https://github.com/toddbluhm/env-cmd/issues/32