### PR TITLE
Allow .json extension for rc file

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,9 +78,9 @@ or
 
 ### `.rc` file usage
 
-For more complex projects, a `.env-cmdrc` file can be defined in the root directory and supports as many environments as you want. Instead of passing the path to a `.env` file to `env-cmd`, simply pass the name of the environment you want to use thats in your `.env-cmdrc` file. You may also use multiple environment names to merge env vars together.
+For more complex projects, a `.env-cmdrc` file (with optional json extension) can be defined in the root directory and supports as many environments as you want. Instead of passing the path to a `.env` file to `env-cmd`, simply pass the name of the environment you want to use thats in your `.env-cmdrc` file. You may also use multiple environment names to merge env vars together.
 
-**.rc file `.env-cmdrc`**
+**.rc file `.env-cmdrc` or `.env-cmdrc.json`**
 
 ```json
 {

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,7 +4,20 @@ const spawn = require('cross-spawn').spawn
 const path = require('path')
 const fs = require('fs')
 const os = require('os')
-const rcFileLocation = path.join(process.cwd(), '.env-cmdrc')
+
+const rcFilenames = [
+  '.env-cmdrc',
+  '.env-cmdrc.json'
+]
+let rcFileLocation = null
+
+rcFilenames.forEach((filename) => {
+  const rcPath = path.join(process.cwd(), filename)
+
+  if (fs.existsSync(rcPath)) {
+    rcFileLocation = rcPath
+  }
+})
 const envFilePathDefault = path.join(process.cwd(), '.env')
 let sharedState = {
   exitCalled: false


### PR DESCRIPTION
Many code editors and IDEs have syntax highlighting and linting based on the file extension. This PR adds a check to see if an `.env-cmdrc.json` exists. If so, it will use that instead.

## Todo

- [x] Write solution
- [x] Add notes in documentation
- [ ] Write tests

## Notable changes

* Add check to see if .env.cmdrc.json exists - `env-cmd` will use that first
* Add notes in README.md

## Before merging

I haven't written tests for the new check, because starting with line [DecentM/env-cmd/test/test.js#208](https://github.com/DecentM/env-cmd/blob/f8f56ec34f8c5098ae59f010b5e5781394ef7fcb/test/test.js#L208), the whole of `existsSync` and `readFileSync` are stubbed. It looks like 100% coverage would require a different way of mocking. Can you point me in the right direction to solve this?