### PR TITLE
fixed ResolveEnvFilePath tests not running on Windows

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
+os:
+  - linux
+  - windows
+
 sudo: required
 dist: trusty
 

--- a/test/test.js
+++ b/test/test.js
@@ -49,6 +49,10 @@ const ResolveEnvFilePath = lib.ResolveEnvFilePath
 const TerminateSpawnedProc = lib.TerminateSpawnedProc
 const TerminateParentProcess = lib.TerminateParentProcess
 
+function fixSlash(path) {
+  return path.replace(/\//g, '\\')
+}
+
 describe('env-cmd', function () {
   describe('ParseArgs', function () {
     it('should parse out --no-override option ', function () {
@@ -412,39 +416,39 @@ describe('env-cmd', function () {
   describe('ResolveEnvFilePath', function () {
     beforeEach(function () {
       this.cwdStub = sinon.stub(process, 'cwd')
-      this.cwdStub.returns('/Users/hitchhikers-guide-to-the-galaxy/Thanks')
+      this.cwdStub.returns(fixSlash('/Users/hitchhikers-guide-to-the-galaxy/Thanks'))
     })
     afterEach(function () {
       this.cwdStub.restore()
     })
     it('should add "fish.env" to the end of the current directory', function () {
       const abPath = ResolveEnvFilePath('fish.env')
-      assert(abPath === '/Users/hitchhikers-guide-to-the-galaxy/Thanks/fish.env')
+      assert(abPath === fixSlash('/Users/hitchhikers-guide-to-the-galaxy/Thanks/fish.env'))
     })
     it('should add "./fish.env" to the end of the current directory', function () {
       const abPath = ResolveEnvFilePath('./fish.env')
-      assert(abPath === '/Users/hitchhikers-guide-to-the-galaxy/Thanks/fish.env')
+      assert(abPath === fixSlash('/Users/hitchhikers-guide-to-the-galaxy/Thanks/fish.env'))
     })
     it('should add "../fish.env" to the end of the current directory', function () {
       const abPath = ResolveEnvFilePath('../fish.env')
-      assert(abPath === '/Users/hitchhikers-guide-to-the-galaxy/fish.env')
+      assert(abPath === fixSlash('/Users/hitchhikers-guide-to-the-galaxy/fish.env'))
     })
     it('should add "for-all-the/fish.env" to the end of the current directory', function () {
       const abPath = ResolveEnvFilePath('for-all-the/fish.env')
-      assert(abPath === '/Users/hitchhikers-guide-to-the-galaxy/Thanks/for-all-the/fish.env')
+      assert(abPath === fixSlash('/Users/hitchhikers-guide-to-the-galaxy/Thanks/for-all-the/fish.env'))
     })
     it('should set the absolute path to "/thanks/for-all-the/fish.env"', function () {
       const abPath = ResolveEnvFilePath('/thanks/for-all-the/fish.env')
-      assert(abPath === '/thanks/for-all-the/fish.env')
+      assert(abPath === fixSlash('/thanks/for-all-the/fish.env'))
     })
     it('should use "~" to add "fish.env" to the end of user directory', function () {
       const abPath = ResolveEnvFilePath('~/fish.env')
-      assert(abPath === '/Users/hitchhikers-guide-to-the-galaxy/fish.env')
+      assert(abPath === fixSlash('/Users/hitchhikers-guide-to-the-galaxy/fish.env'))
     })
     it('should leave "~" in path if no user home directory found', function () {
       userHomeDir = ''
       const abPath = ResolveEnvFilePath('~/fish.env')
-      assert(abPath === '/Users/hitchhikers-guide-to-the-galaxy/Thanks/~/fish.env')
+      assert(abPath === fixSlash('/Users/hitchhikers-guide-to-the-galaxy/Thanks/~/fish.env'))
     })
   })
 

--- a/test/test.js
+++ b/test/test.js
@@ -7,6 +7,7 @@ const afterEach = require('mocha').afterEach
 const beforeEach = require('mocha').beforeEach
 const before = require('mocha').before
 const after = require('mocha').after
+const os = require('os')
 const path = require('path')
 const proxyquire = require('proxyquire')
 const sinon = require('sinon')
@@ -50,7 +51,8 @@ const TerminateSpawnedProc = lib.TerminateSpawnedProc
 const TerminateParentProcess = lib.TerminateParentProcess
 
 function fixSlash(path) {
-  return path.replace(/\//g, '\\')
+  if (os.type() === 'Windows_NT') return path.replace(/\\/g, '/')
+  return path
 }
 
 describe('env-cmd', function () {
@@ -416,39 +418,39 @@ describe('env-cmd', function () {
   describe('ResolveEnvFilePath', function () {
     beforeEach(function () {
       this.cwdStub = sinon.stub(process, 'cwd')
-      this.cwdStub.returns(fixSlash('/Users/hitchhikers-guide-to-the-galaxy/Thanks'))
+      this.cwdStub.returns('/Users/hitchhikers-guide-to-the-galaxy/Thanks')
     })
     afterEach(function () {
       this.cwdStub.restore()
     })
     it('should add "fish.env" to the end of the current directory', function () {
-      const abPath = ResolveEnvFilePath('fish.env')
-      assert(abPath === fixSlash('/Users/hitchhikers-guide-to-the-galaxy/Thanks/fish.env'))
+      const abPath = fixSlash(ResolveEnvFilePath('fish.env'))
+      assert(abPath === '/Users/hitchhikers-guide-to-the-galaxy/Thanks/fish.env')
     })
     it('should add "./fish.env" to the end of the current directory', function () {
-      const abPath = ResolveEnvFilePath('./fish.env')
-      assert(abPath === fixSlash('/Users/hitchhikers-guide-to-the-galaxy/Thanks/fish.env'))
+      const abPath = fixSlash(ResolveEnvFilePath('./fish.env'))
+      assert(abPath === '/Users/hitchhikers-guide-to-the-galaxy/Thanks/fish.env')
     })
     it('should add "../fish.env" to the end of the current directory', function () {
-      const abPath = ResolveEnvFilePath('../fish.env')
-      assert(abPath === fixSlash('/Users/hitchhikers-guide-to-the-galaxy/fish.env'))
+      const abPath = fixSlash(ResolveEnvFilePath('../fish.env'))
+      assert(abPath === '/Users/hitchhikers-guide-to-the-galaxy/fish.env')
     })
     it('should add "for-all-the/fish.env" to the end of the current directory', function () {
-      const abPath = ResolveEnvFilePath('for-all-the/fish.env')
-      assert(abPath === fixSlash('/Users/hitchhikers-guide-to-the-galaxy/Thanks/for-all-the/fish.env'))
+      const abPath = fixSlash(ResolveEnvFilePath('for-all-the/fish.env'))
+      assert(abPath === '/Users/hitchhikers-guide-to-the-galaxy/Thanks/for-all-the/fish.env')
     })
     it('should set the absolute path to "/thanks/for-all-the/fish.env"', function () {
-      const abPath = ResolveEnvFilePath('/thanks/for-all-the/fish.env')
-      assert(abPath === fixSlash('/thanks/for-all-the/fish.env'))
+      const abPath = fixSlash(ResolveEnvFilePath('/thanks/for-all-the/fish.env'))
+      assert(abPath === '/thanks/for-all-the/fish.env')
     })
     it('should use "~" to add "fish.env" to the end of user directory', function () {
-      const abPath = ResolveEnvFilePath('~/fish.env')
-      assert(abPath === fixSlash('/Users/hitchhikers-guide-to-the-galaxy/fish.env'))
+      const abPath = fixSlash(ResolveEnvFilePath('~/fish.env'))
+      assert(abPath === '/Users/hitchhikers-guide-to-the-galaxy/fish.env')
     })
     it('should leave "~" in path if no user home directory found', function () {
       userHomeDir = ''
-      const abPath = ResolveEnvFilePath('~/fish.env')
-      assert(abPath === fixSlash('/Users/hitchhikers-guide-to-the-galaxy/Thanks/~/fish.env'))
+      const abPath = fixSlash(ResolveEnvFilePath('~/fish.env'))
+      assert(abPath === '/Users/hitchhikers-guide-to-the-galaxy/Thanks/~/fish.env')
     })
   })
 


### PR DESCRIPTION
The ResolveEnvFilePath tests were not running correctly on Windows, because the path separator was incorrect.