### PR TITLE
Added --use-shell option

### DIFF
--- a/.env.test-me
+++ b/.env.test-me
@@ -1,0 +1,1 @@
+HELLO=WORLD

--- a/README.md
+++ b/README.md
@@ -87,7 +87,6 @@ pass the name of the environment you want to use thats in your `.env-cmdrc` file
 multiple environment names to merge env vars together.
 
 **.rc file `.env-cmdrc`**
-
 ```json
 {
   "development": {
@@ -119,6 +118,56 @@ Sometimes you want to set env variables from a file without overriding existing 
 **Terminal**
 ```sh
 ENV1=welcome ./node_modules/.bin/env-cmd --no-override ./test/.env node index.js
+```
+
+### `--use-shell` option
+
+Sometimes you want to set env variables that are available to multiple commands instead of just one command or are available as command line arguments.
+
+### Available as commandline arguments
+
+**dot env file `.env.local`**
+```
+HELLO=WORLD
+```
+
+**Terminal**
+```sh
+# no --use-shell
+node bin/env-cmd --fallback .env.local echo %HELLO%
+# result: %HELLO%
+
+# with --use-shell
+node bin/env-cmd --fallback .env.local --use-shell echo %HELLO%
+# result: WORLD
+```
+
+> **NOTE** The quotes around the commands are required for them to be interpreted correctly.
+
+### Available to multiple commands
+
+**command `cmd.js`**
+```js
+console.log(process.env.GOODBYE)
+```
+
+**dot env file `.env.local`**
+```
+GOODBYE=BYE
+```
+
+**Terminal**
+```sh
+# no --use-shell
+node bin/env-cmd --fallback .env.local "node cmd && node cmd"
+# result:
+# * BYE
+
+# with --use-shell
+node bin/env-cmd --fallback .env.local --use-shell "node cmd && node cmd"
+# result:
+# BYE
+# BYE
 ```
 
 ## Examples

--- a/lib/index.js
+++ b/lib/index.js
@@ -46,6 +46,7 @@ function EnvCmd (args) {
   // Execute the command with the given environment variables
   const proc = spawn(parsedArgs.command, parsedArgs.commandArgs, {
     stdio: 'inherit',
+    shell: parsedArgs.useShell,
     env
   })
 
@@ -78,6 +79,7 @@ function ParseArgs (args) {
   let command
   let noOverride
   let useFallback
+  let useShell
   let commandArgs = args.slice()
   while (commandArgs.length) {
     const arg = commandArgs.shift()
@@ -87,6 +89,10 @@ function ParseArgs (args) {
     }
     if (arg === '--no-override') {
       noOverride = true
+      continue
+    }
+    if (arg === '--use-shell') {
+      useShell = true
       continue
     }
     // assume the first arg is the env file (or if using .rc the environment name)
@@ -103,7 +109,8 @@ function ParseArgs (args) {
     command,
     commandArgs,
     noOverride,
-    useFallback
+    useFallback,
+    useShell
   }
 }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -289,6 +289,7 @@ environment configs in one file.
 Options:
   --no-override - do not override existing process env vars with file env vars
   --fallback - if provided env file does not exist, attempt to use fallback .env file in root dir
+  --use-shell - make env variables available to multiple commands and as command line arguments
   `
 }
 

--- a/test/test.js
+++ b/test/test.js
@@ -56,6 +56,11 @@ describe('env-cmd', function () {
       assert(parsedArgs.noOverride === true)
     })
 
+    it('should parse out --use-shell option ', function () {
+      const parsedArgs = ParseArgs(['--use-shell', './test/envFile', 'command', 'cmda1', 'cmda2'])
+      assert(parsedArgs.useShell === true)
+    })
+
     it('should parse out the envfile', function () {
       const parsedArgs = ParseArgs(['./test/envFile', 'command', 'cmda1', 'cmda2'])
       assert(parsedArgs.envFile === './test/envFile')
@@ -346,6 +351,20 @@ describe('env-cmd', function () {
       assert(spawnStub.args[0][2].env.BOB === 'SUPERCOOL')
       assert(spawnStub.args[0][2].env.NODE_ENV === 'development')
       assert(spawnStub.args[0][2].env.ANSWER === '42')
+    })
+
+    it('should spawn a new process using the shell option', function () {
+      process.env.NODE_ENV = 'development'
+      process.env.BOB = 'SUPERCOOL'
+      this.readFileStub.returns('BOB=COOL\nNODE_ENV=dev\nANSWER=42\n')
+      EnvCmd(['--use-shell', './test/.env', 'echo', '$BOB'])
+      assert(this.readFileStub.args[0][0] === path.join(process.cwd(), 'test/.env'))
+      assert(spawnStub.args[0][0] === 'echo')
+      assert(spawnStub.args[0][1][0] === '$BOB')
+      assert(spawnStub.args[0][2].env.BOB === 'COOL')
+      assert(spawnStub.args[0][2].env.NODE_ENV === 'dev')
+      assert(spawnStub.args[0][2].env.ANSWER === '42')
+      assert(spawnStub.args[0][2].shell === true)
     })
 
     it('should throw error if file and fallback does not exist with --fallback option', function () {


### PR DESCRIPTION
Added --use-shell option to be able to set an environment variable accross an entire inline shell script, instead of just one command. This enables use cases like calling a Windows command.

Example command:

```
node bin/env-cmd --fallback .env.test-me --use-shell echo %HELLO%
```

Example .env.local file:
```
HELLO=WORLD
```

Without --use-shell the result is:

```
%HELLO%
```

With --use-shell the result is:

```
WORLD
```
