### PR TITLE
Added warning message if env file does not exist and fallback is not specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,11 +123,11 @@ ENV1=welcome ./node_modules/.bin/env-cmd --no-override ./test/.env node index.js
 
 ### `--no-warn` option
 
-By default a warning is displayed if the env file and fallback file do not exist. If the `--fallback` option is not specified and the env file does not exist the warning message will also be displayed. This warning message can be suppressed with the `--no-warn` option.
+By default a warning is displayed if the env file does not exist and the `--fallback` option is not specified. This warning message can be suppressed with the `--no-warn` option.
 
 **Terminal**
 ```sh
-./node_modules/.bin/env-cmd --no-warn ./.env.does-no-exist --fallback node index.js
+./node_modules/.bin/env-cmd --no-warn ./.env.does-no-exist node index.js
 ```
 
 ## Examples

--- a/README.md
+++ b/README.md
@@ -121,6 +121,15 @@ Sometimes you want to set env variables from a file without overriding existing 
 ENV1=welcome ./node_modules/.bin/env-cmd --no-override ./test/.env node index.js
 ```
 
+### `--no-warn` option
+
+By default a warning is displayed if the env file and fallback file do not exist. If the `--fallback` option is not specified and the env file does not exist the warning message will also be displayed. This warning message can be suppressed with the `--no-warn` option.
+
+**Terminal**
+```sh
+./node_modules/.bin/env-cmd --no-warn ./.env.does-no-exist --fallback node index.js
+```
+
 ## Examples
 
 You can find examples of how to use the various options above by visiting

--- a/lib/index.js
+++ b/lib/index.js
@@ -34,6 +34,10 @@ function EnvCmd (args) {
     parsedEnv = UseCmdLine({ envFile: parsedArgs.envFile, useFallback: parsedArgs.useFallback })
   }
 
+  if (!Object.keys(parsedEnv).length && !parsedArgs.noWarn) {
+    console.warn(`WARNING: Could not find env file or fallback file (${envFilePathDefault})`)
+  }
+
   let env
   // Override the merge order if --no-override flag set
   if (parsedArgs.noOverride) {
@@ -78,6 +82,7 @@ function ParseArgs (args) {
   let command
   let noOverride
   let useFallback
+  let noWarn = false
   let commandArgs = args.slice()
   while (commandArgs.length) {
     const arg = commandArgs.shift()
@@ -87,6 +92,10 @@ function ParseArgs (args) {
     }
     if (arg === '--no-override') {
       noOverride = true
+      continue
+    }
+    if (arg === '--no-warn') {
+      noWarn = true
       continue
     }
     // assume the first arg is the env file (or if using .rc the environment name)
@@ -103,7 +112,8 @@ function ParseArgs (args) {
     command,
     commandArgs,
     noOverride,
-    useFallback
+    useFallback,
+    noWarn
   }
 }
 
@@ -251,7 +261,7 @@ function UseCmdLine (options) {
     try {
       file = fs.readFileSync(envFilePathDefault)
     } catch (e) {
-      throw new Error(`Error! Could not find fallback file or read env file at ${envFilePathDefault}`)
+      throw new Error(`ERROR: Could not find env file or fallback file (${envFilePathDefault})`)
     }
   }
 
@@ -282,6 +292,7 @@ environment configs in one file.
 Options:
   --no-override - do not override existing process env vars with file env vars
   --fallback - if provided env file does not exist, attempt to use fallback .env file in root dir
+  --no-warn - do not warn if no env file is not found
   `
 }
 

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,0 +1,26 @@
+let output = ''
+const write = process.stdout.write
+const log = console.log
+const warn = console.warn
+const error = console.error
+
+module.exports = {
+  captureOutput: function() {
+    output = ''
+    process.stdout.write = console.log = console.warn = console.error = function(string) {
+      if (!string) return
+      output += string
+    }
+  },
+
+  getOutput: function() {
+    return output
+  },
+
+  restoreOutput: function() {
+    process.stdout.write = write
+    console.log = log
+    console.warn = warn
+    console.error = error
+  }
+}

--- a/test/test.js
+++ b/test/test.js
@@ -380,6 +380,19 @@ describe('env-cmd', function () {
       assert(helpers.getOutput().indexOf(`WARNING: Could not find env file or fallback file (${resolvedPath})`) === -1)
     })
 
+    it('should throw error if file and fallback do not exist with --fallback and --no-warn options', function () {
+      this.readFileStub.restore()
+
+      try {
+        EnvCmd(['--fallback', '--no-warn', './test/.non-existent-file', 'echo', '$BOB'])
+      } catch (e) {
+        const resolvedPath = path.join(process.cwd(), '.env')
+        assert(e.message === `ERROR: Could not find env file or fallback file (${resolvedPath})`)
+        return
+      }
+      assert(!'No exception thrown')
+    })
+
     it('should execute successfully if no env file found', function () {
       this.readFileStub.restore()
       process.env.NODE_ENV = 'dev'

--- a/test/test.js
+++ b/test/test.js
@@ -11,6 +11,7 @@ const path = require('path')
 const proxyquire = require('proxyquire')
 const sinon = require('sinon')
 const fs = require('fs')
+const helpers = require('./helpers')
 let userHomeDir = '/Users/hitchhikers-guide-to-the-galaxy'
 
 const spawnStub = sinon.spy(() => ({
@@ -355,10 +356,28 @@ describe('env-cmd', function () {
         EnvCmd(['--fallback', './test/.non-existent-file', 'echo', '$BOB'])
       } catch (e) {
         const resolvedPath = path.join(process.cwd(), '.env')
-        assert(e.message === `Error! Could not find fallback file or read env file at ${resolvedPath}`)
+        assert(e.message === `ERROR: Could not find env file or fallback file (${resolvedPath})`)
         return
       }
       assert(!'No exception thrown')
+    })
+
+    it('should display warning if env file and fallback do not exist and --no-warn is NOT specified', function () {
+      this.readFileStub.restore()
+      helpers.captureOutput()
+      EnvCmd(['./test/.non-existent-file', 'echo', '$BOB'])
+      helpers.restoreOutput()
+      const resolvedPath = path.join(process.cwd(), '.env')
+      assert(helpers.getOutput().indexOf(`WARNING: Could not find env file or fallback file (${resolvedPath})`) >= 0)
+    })
+
+    it('should NOT display warning if env file and fallback do not exist and --no-warn is specified', function () {
+      this.readFileStub.restore()
+      helpers.captureOutput()
+      EnvCmd(['--no-warn', './test/.non-existent-file', 'echo', '$BOB'])
+      helpers.restoreOutput()
+      const resolvedPath = path.join(process.cwd(), '.env')
+      assert(helpers.getOutput().indexOf(`WARNING: Could not find env file or fallback file (${resolvedPath})`) === -1)
     })
 
     it('should execute successfully if no env file found', function () {


### PR DESCRIPTION
Currently there is no warning when the env file does not exist and the `--fallback` option is not specified. This can be frustrating for users as it might not be clear why the command/script that is called is not functioning correctly.

I have added a warning message that is displayed if the env file does not exist and the `--fallback` option is not specified. This warning message can be suppressed with the `--no-warn` option.

**Terminal**
```sh
./node_modules/.bin/env-cmd --no-warn ./.env.does-no-exist --fallback node index.js
```