### PR TITLE
Added Env default locations

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,10 +134,11 @@ the examples repo [env-cmd-examples](https://github.com/toddbluhm/env-cmd-exampl
 ## Environment File Formats
 
 These are the currently accepted environment file formats. If any other formats are desired please create an issue.
-- `key=value`
-- Key/value pairs as JSON
-- JavaScript file exporting an `object` or a `Promise` that resolves to an `object`
-- `.env-cmdrc` file (as valid json) in execution directory
+- `.env` as `key=value`
+- `.env.json` Key/value pairs as JSON
+- `.env.js` JavaScript file exporting an `object` or a `Promise` that resolves to an `object`
+- `.env-cmdrc` as valid json or `.env-cmdrc.json` in execution directory with at least one environment `{ "dev": { "key1": "val1" } }`
+- `.env-cmdrc.js` JavaScript file exporting an `object` or a `Promise` that resolves to an `object` that contains at least one environment
 
 ## Path Rules
 

--- a/dist/get-env-vars.js
+++ b/dist/get-env-vars.js
@@ -11,7 +11,7 @@ Object.defineProperty(exports, "__esModule", { value: true });
 const parse_rc_file_1 = require("./parse-rc-file");
 const parse_env_file_1 = require("./parse-env-file");
 const RC_FILE_DEFAULT_LOCATIONS = ['./.env-cmdrc', './.env-cmdrc.js', './.env-cmdrc.json'];
-const ENV_FILE_DEFAULT_LOCATION = './.env';
+const ENV_FILE_DEFAULT_LOCATIONS = ['./.env', './.env.js', './.env.json'];
 function getEnvVars(options) {
     return __awaiter(this, void 0, void 0, function* () {
         options = options || {};
@@ -36,13 +36,14 @@ function getEnvFile({ filePath, fallback }) {
                 throw new Error(`Unable to locate env file at location (${filePath})`);
             }
         }
-        // Use the default env file location
-        try {
-            return yield parse_env_file_1.getEnvFileVars(ENV_FILE_DEFAULT_LOCATION);
+        // Use the default env file locations
+        for (const path of ENV_FILE_DEFAULT_LOCATIONS) {
+            try {
+                return yield parse_env_file_1.getEnvFileVars(path);
+            }
+            catch (e) { }
         }
-        catch (e) {
-            throw new Error(`Unable to locate env file at default location (${ENV_FILE_DEFAULT_LOCATION})`);
-        }
+        throw new Error(`Unable to locate env file at default locations (${ENV_FILE_DEFAULT_LOCATIONS})`);
     });
 }
 exports.getEnvFile = getEnvFile;

--- a/src/get-env-vars.ts
+++ b/src/get-env-vars.ts
@@ -3,7 +3,7 @@ import { getRCFileVars } from './parse-rc-file'
 import { getEnvFileVars } from './parse-env-file'
 
 const RC_FILE_DEFAULT_LOCATIONS = ['./.env-cmdrc', './.env-cmdrc.js', './.env-cmdrc.json']
-const ENV_FILE_DEFAULT_LOCATION = './.env'
+const ENV_FILE_DEFAULT_LOCATIONS = ['./.env', './.env.js', './.env.json']
 
 export async function getEnvVars (options?: GetEnvVarOptions): Promise<{ [key: string]: any }> {
   options = options || {}
@@ -28,12 +28,14 @@ export async function getEnvFile (
     }
   }
 
-  // Use the default env file location
-  try {
-    return await getEnvFileVars(ENV_FILE_DEFAULT_LOCATION)
-  } catch (e) {
-    throw new Error(`Unable to locate env file at default location (${ENV_FILE_DEFAULT_LOCATION})`)
+  // Use the default env file locations
+  for (const path of ENV_FILE_DEFAULT_LOCATIONS) {
+    try {
+      return await getEnvFileVars(path)
+    } catch (e) { }
   }
+
+  throw new Error(`Unable to locate env file at default locations (${ENV_FILE_DEFAULT_LOCATIONS})`)
 }
 
 export async function getRCFile (


### PR DESCRIPTION
env-cmd already supported `.env.js` and `.env.json`, so I simply added it to the default lookup and updated the README to clarify each file and usage.