### PR TITLE
feat: Support env vars expansion in cmd and args

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Options:
   -f, --file [path]                   Custom env file path (default path: ./.env)
   -r, --rc-file [path]                Custom rc file path (default path: ./.env-cmdrc(|.js|.json)
   -e, --environments [env1,env2,...]  The rc file environment(s) to use
+  -x, --expand-envs                   Replace $var in args and command with environment variables 
   --fallback                          Fallback to default env file path, if custom env file path not found
   --no-override                       Do not override existing environment variables
   --use-shell                         Execute the command in a new shell with the given environment

--- a/dist/env-cmd.js
+++ b/dist/env-cmd.js
@@ -4,6 +4,7 @@ const spawn_1 = require("./spawn");
 const signal_termination_1 = require("./signal-termination");
 const parse_args_1 = require("./parse-args");
 const get_env_vars_1 = require("./get-env-vars");
+const expand_envs_1 = require("./expand-envs");
 /**
  * Executes env - cmd using command line arguments
  * @export
@@ -40,6 +41,10 @@ async function EnvCmd({ command, commandArgs, envFile, rc, options = {} }) {
     else {
         // Add in the system environment variables to our environment list
         env = Object.assign({}, process.env, env);
+    }
+    if (options.expandEnvs === true) {
+        command = expand_envs_1.expandEnvs(command, env);
+        commandArgs = commandArgs.map(arg => expand_envs_1.expandEnvs(arg, env));
     }
     // Execute the command with the given environment variables
     const proc = spawn_1.spawn(command, commandArgs, {

--- a/dist/expand-envs.d.ts
+++ b/dist/expand-envs.d.ts
@@ -1,0 +1,7 @@
+/**
+ * expandEnvs Replaces $var in args and command with environment variables
+ * the environment variable doesn't exist, it leaves it as is.
+*/
+export declare function expandEnvs(str: string, envs: {
+    [key: string]: any;
+}): string;

--- a/dist/expand-envs.js
+++ b/dist/expand-envs.js
@@ -1,0 +1,13 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+/**
+ * expandEnvs Replaces $var in args and command with environment variables
+ * the environment variable doesn't exist, it leaves it as is.
+*/
+function expandEnvs(str, envs) {
+    return str.replace(/(?<!\\)\$[a-zA-Z0-9_]+/g, varName => {
+        const varValue = envs[varName.slice(1)];
+        return varValue === undefined ? varName : varValue;
+    });
+}
+exports.expandEnvs = expandEnvs;

--- a/dist/parse-args.js
+++ b/dist/parse-args.js
@@ -14,6 +14,7 @@ function parseArgs(args) {
     program = parseArgsUsingCommander(args.slice(0, args.indexOf(command)));
     const noOverride = !program.override;
     const useShell = !!program.useShell;
+    const expandEnvs = !!program.expandEnvs;
     const verbose = !!program.verbose;
     let rc;
     if (program.environments !== undefined && program.environments.length !== 0) {
@@ -37,7 +38,8 @@ function parseArgs(args) {
         options: {
             noOverride,
             useShell,
-            verbose
+            verbose,
+            expandEnvs
         }
     };
     if (verbose === true) {
@@ -57,6 +59,7 @@ function parseArgsUsingCommander(args) {
         .option('--fallback', 'Fallback to default env file path, if custom env file path not found')
         .option('--no-override', 'Do not override existing environment variables')
         .option('--use-shell', 'Execute the command in a new shell with the given environment')
+        .option('-x, --expand-envs', 'Replace $var in args and command with environment variables')
         .option('--verbose', 'Print helpful debugging information')
         .parse(['_', '_', ...args]);
 }

--- a/dist/types.d.ts
+++ b/dist/types.d.ts
@@ -16,5 +16,6 @@ export interface EnvCmdOptions extends GetEnvVarOptions {
         noOverride?: boolean;
         useShell?: boolean;
         verbose?: boolean;
+        expandEnvs?: boolean;
     };
 }

--- a/src/env-cmd.ts
+++ b/src/env-cmd.ts
@@ -3,6 +3,7 @@ import { EnvCmdOptions } from './types'
 import { TermSignals } from './signal-termination'
 import { parseArgs } from './parse-args'
 import { getEnvVars } from './get-env-vars'
+import { expandEnvs } from './expand-envs'
 
 /**
  * Executes env - cmd using command line arguments
@@ -41,6 +42,11 @@ export async function EnvCmd (
   } else {
     // Add in the system environment variables to our environment list
     env = Object.assign({}, process.env, env)
+  }
+
+  if (options.expandEnvs === true) {
+    command = expandEnvs(command, env)
+    commandArgs = commandArgs.map(arg => expandEnvs(arg, env))
   }
 
   // Execute the command with the given environment variables

--- a/src/expand-envs.ts
+++ b/src/expand-envs.ts
@@ -1,0 +1,11 @@
+
+/**
+ * expandEnvs Replaces $var in args and command with environment variables
+ * the environment variable doesn't exist, it leaves it as is.
+*/
+export function expandEnvs (str: string, envs: { [key: string]: any }): string {
+  return str.replace(/(?<!\\)\$[a-zA-Z0-9_]+/g, varName => {
+    const varValue = envs[varName.slice(1)]
+    return varValue === undefined ? varName : varValue
+  })
+}

--- a/src/parse-args.ts
+++ b/src/parse-args.ts
@@ -15,6 +15,7 @@ export function parseArgs (args: string[]): EnvCmdOptions {
   program = parseArgsUsingCommander(args.slice(0, args.indexOf(command)))
   const noOverride = !(program.override as boolean)
   const useShell = !!(program.useShell as boolean)
+  const expandEnvs = !!(program.expandEnvs as boolean)
   const verbose = !!(program.verbose as boolean)
 
   let rc: any
@@ -41,7 +42,8 @@ export function parseArgs (args: string[]): EnvCmdOptions {
     options: {
       noOverride,
       useShell,
-      verbose
+      verbose,
+      expandEnvs
     }
   }
   if (verbose === true) {
@@ -61,6 +63,7 @@ export function parseArgsUsingCommander (args: string[]): Command {
     .option('--fallback', 'Fallback to default env file path, if custom env file path not found')
     .option('--no-override', 'Do not override existing environment variables')
     .option('--use-shell', 'Execute the command in a new shell with the given environment')
+    .option('-x, --expand-envs', 'Replace $var in args and command with environment variables')
     .option('--verbose', 'Print helpful debugging information')
     .parse(['_', '_', ...args])
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,5 +17,6 @@ export interface EnvCmdOptions extends GetEnvVarOptions {
     noOverride?: boolean
     useShell?: boolean
     verbose?: boolean
+    expandEnvs?: boolean
   }
 }

--- a/test/expand-envs.spec.ts
+++ b/test/expand-envs.spec.ts
@@ -1,0 +1,19 @@
+/* eslint @typescript-eslint/no-non-null-assertion: 0 */
+import { assert } from 'chai'
+import { expandEnvs } from '../src/expand-envs'
+
+describe('expandEnvs', (): void => {
+  const envs = {
+    notvar: 'this is not used',
+    dollar: 'money',
+    PING: 'PONG',
+    IP1: '127.0.0.1'
+  }
+  const args = ['notvar', '$dollar', '\\$notvar', '-4', '$PING', '$IP1', '\\$IP1', '$NONEXIST']
+  const argsExpanded = ['notvar', 'money', '\\$notvar', '-4', 'PONG', '127.0.0.1', '\\$IP1', '$NONEXIST']
+
+  it('should replace environment variables in args', (): void => {
+    const res = args.map(arg => expandEnvs(arg, envs))
+    assert.sameOrderedMembers(res, argsExpanded)
+  })
+})


### PR DESCRIPTION
This pull request adds support for expanding environment variable
expansion support. Closes #91

Since the user controls the call site of cmd-env, it only supports
basic UNIX style $var format. `%var%` (windows) or `${var}` is not
supported. However, you can escape variable expansion by escaping
the dollar sign like so `\$`.

Signed-off-by: omeid matten <public@omeid.me>