### PR TITLE
fix: add  type module support

### DIFF
--- a/dist/parse-env-file.js
+++ b/dist/parse-env-file.js
@@ -3,7 +3,7 @@ Object.defineProperty(exports, "__esModule", { value: true });
 const fs = require("fs");
 const path = require("path");
 const utils_1 = require("./utils");
-const REQUIRE_HOOK_EXTENSIONS = ['.json', '.js'];
+const REQUIRE_HOOK_EXTENSIONS = ['.json', '.js', '.cjs'];
 /**
  * Gets the environment vars from an env file
  */

--- a/dist/parse-rc-file.js
+++ b/dist/parse-rc-file.js
@@ -23,7 +23,7 @@ async function getRCFileVars({ environments, filePath }) {
     const ext = path_1.extname(absolutePath).toLowerCase();
     let parsedData;
     try {
-        if (ext === '.json' || ext === '.js') {
+        if (ext === '.json' || ext === '.js' || ext === '.cjs') {
             const possiblePromise = require(absolutePath); /* eslint-disable-line */
             parsedData = utils_1.isPromise(possiblePromise) ? await possiblePromise : possiblePromise;
         }

--- a/src/parse-env-file.ts
+++ b/src/parse-env-file.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs'
 import * as path from 'path'
 import { resolveEnvFilePath, isPromise } from './utils'
 
-const REQUIRE_HOOK_EXTENSIONS = ['.json', '.js']
+const REQUIRE_HOOK_EXTENSIONS = ['.json', '.js', '.cjs']
 
 /**
  * Gets the environment vars from an env file

--- a/src/parse-rc-file.ts
+++ b/src/parse-rc-file.ts
@@ -26,7 +26,7 @@ export async function getRCFileVars (
   const ext = extname(absolutePath).toLowerCase()
   let parsedData: { [key: string]: any }
   try {
-    if (ext === '.json' || ext === '.js') {
+    if (ext === '.json' || ext === '.js' || ext === '.cjs') {
       const possiblePromise = require(absolutePath) /* eslint-disable-line */
       parsedData = isPromise(possiblePromise) ? await possiblePromise : possiblePromise
     } else {


### PR DESCRIPTION
With [ES Modules](https://blog.logrocket.com/es-modules-in-node-js-12-from-experimental-to-release/) project,in package.json:
`  
"type": "module"
`

error:
```
change the requiring code to use import(), or remove "type": "module" from package.json.

    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1163:13)
```

Fix allow this execution format:
```
env-cmd --rc-file .env-cmdrc.cjs -e development node .
```