### PR TITLE
Fix stripComments()

### DIFF
--- a/src/parse-env-file.ts
+++ b/src/parse-env-file.ts
@@ -66,14 +66,8 @@ export function parseEnvVars (envString: string): { [key: string]: string } {
  * Strips out comments from env file string
  */
 export function stripComments (envString: string): string {
-  const commentsRegex = /(^#.*$)/gim
-  let match = commentsRegex.exec(envString)
-  let newString = envString
-  while (match != null) {
-    newString = newString.replace(match[1], '')
-    match = commentsRegex.exec(envString)
-  }
-  return newString
+  const commentsRegex = /(^\s*#.*$)/gim
+  return envString.replace(commentsRegex, '')
 }
 
 /**

--- a/src/signal-termination.ts
+++ b/src/signal-termination.ts
@@ -89,12 +89,12 @@ export class TermSignals {
    */
   public _terminateProcess (code?: number, signal?: NodeJS.Signals): void {
     if (signal !== undefined) {
-      return process.kill(process.pid, signal)
+      process.kill(process.pid, signal)
+    } else if (code !== undefined) {
+      process.exit(code)
+    } else {
+      throw new Error('Unable to terminate parent process successfully')
     }
-    if (code !== undefined) {
-      return process.exit(code)
-    }
-    throw new Error('Unable to terminate parent process successfully')
   }
 
   /**

--- a/test/parse-env-file.spec.ts
+++ b/test/parse-env-file.spec.ts
@@ -16,6 +16,12 @@ describe('stripComments', (): void => {
     const envString = stripComments('#BOB=COOL\nNODE_ENV=dev\nANSWER=42 AND COUNTING\n#AnotherComment\n')
     assert(envString === '\nNODE_ENV=dev\nANSWER=42 AND COUNTING\n\n')
   })
+
+  it('should not strip out #s from values', (): void => {
+    const envString = stripComments('#\nBOB=COMMENT#ELL\n#\nNODE_ENV=dev\nANSWER=42 AND COUNTING\n#AnotherComment\n')
+    assert(envString === '\nBOB=COMMENT#ELL\n\nNODE_ENV=dev\nANSWER=42 AND COUNTING\n\n', envString)
+  })
+
 })
 
 describe('parseEnvVars', (): void => {


### PR DESCRIPTION
If you have a value containing a `#` followed at some point by a line containing only `#\n`, the wrong `#` will be removed by `stripComments()`.

This PR both fixes this issue and simplifies `stripComments()`.