### PR TITLE
feat: add support for parameter expansion

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,22 @@ or in `package.json` (use `\\` to insert a literal backslash)
 }
 ```
 
+It will also work with parameter expansion
+
+```sh
+./node_modules/.bin/env-cmd -x echo "Hello ${WHO}!"
+```
+
+or in `package.json`:
+
+```json
+{
+  "script": {
+    "hello": "env-cmd -x echo \"Hello ${WHO}!\""
+  }
+}
+```
+
 
 ### `--silent` suppresses env-cmd errors
 

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ or in `package.json` (use `\\` to insert a literal backslash)
 It will also work with parameter expansion
 
 ```sh
-./node_modules/.bin/env-cmd -x echo "Hello ${WHO}!"
+./node_modules/.bin/env-cmd -x echo "Hello \${WHO}!"
 ```
 
 or in `package.json`:
@@ -176,7 +176,7 @@ or in `package.json`:
 ```json
 {
   "script": {
-    "hello": "env-cmd -x echo \"Hello ${WHO}!\""
+    "hello": "env-cmd -x echo \"Hello \\${WHO}!\""
   }
 }
 ```

--- a/dist/env-cmd.js
+++ b/dist/env-cmd.js
@@ -1,5 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.EnvCmd = exports.CLI = void 0;
 const spawn_1 = require("./spawn");
 const signal_termination_1 = require("./signal-termination");
 const parse_args_1 = require("./parse-args");

--- a/dist/expand-envs.js
+++ b/dist/expand-envs.js
@@ -1,13 +1,14 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.expandEnvs = void 0;
 /**
  * expandEnvs Replaces $var in args and command with environment variables
  * the environment variable doesn't exist, it leaves it as is.
 */
 function expandEnvs(str, envs) {
-    return str.replace(/(?<!\\)\$[a-zA-Z0-9_]+/g, varName => {
-        const varValue = envs[varName.slice(1)];
-        return varValue === undefined ? varName : varValue;
+    return str.replace(/(?<!\\)\$\{?([a-zA-Z0-9_]+)\}?/g, (_, varName) => {
+        const varValue = envs[varName];
+        return varValue === undefined ? `$${varName}` : varValue;
     });
 }
 exports.expandEnvs = expandEnvs;

--- a/dist/get-env-vars.js
+++ b/dist/get-env-vars.js
@@ -1,5 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.getRCFile = exports.getEnvFile = exports.getEnvVars = void 0;
 const parse_rc_file_1 = require("./parse-rc-file");
 const parse_env_file_1 = require("./parse-env-file");
 const RC_FILE_DEFAULT_LOCATIONS = ['./.env-cmdrc', './.env-cmdrc.js', './.env-cmdrc.json'];

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,8 +1,18 @@
 "use strict";
-function __export(m) {
-    for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
-}
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    Object.defineProperty(o, k2, { enumerable: true, get: function() { return m[k]; } });
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __exportStar = (this && this.__exportStar) || function(m, exports) {
+    for (var p in m) if (p !== "default" && !exports.hasOwnProperty(p)) __createBinding(exports, m, p);
+};
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.GetEnvVars = void 0;
 const get_env_vars_1 = require("./get-env-vars");
-__export(require("./env-cmd"));
+// Export the core env-cmd API
+__exportStar(require("./types"), exports);
+__exportStar(require("./env-cmd"), exports);
 exports.GetEnvVars = get_env_vars_1.getEnvVars;

--- a/dist/parse-args.js
+++ b/dist/parse-args.js
@@ -1,5 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.parseArgsUsingCommander = exports.parseArgs = void 0;
 const commander = require("commander");
 const utils_1 = require("./utils");
 // Use commonjs require to prevent a weird folder hierarchy in dist

--- a/dist/parse-env-file.js
+++ b/dist/parse-env-file.js
@@ -1,5 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.stripEmptyLines = exports.stripComments = exports.parseEnvVars = exports.parseEnvString = exports.getEnvFileVars = void 0;
 const fs = require("fs");
 const path = require("path");
 const utils_1 = require("./utils");

--- a/dist/parse-rc-file.js
+++ b/dist/parse-rc-file.js
@@ -1,5 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.getRCFileVars = void 0;
 const fs_1 = require("fs");
 const util_1 = require("util");
 const path_1 = require("path");

--- a/dist/signal-termination.js
+++ b/dist/signal-termination.js
@@ -1,5 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.TermSignals = void 0;
 const SIGNALS_TO_HANDLE = [
     'SIGINT', 'SIGTERM', 'SIGHUP'
 ];
@@ -82,7 +83,8 @@ class TermSignals {
      */
     _terminateProcess(code, signal) {
         if (signal !== undefined) {
-            return process.kill(process.pid, signal);
+            process.kill(process.pid, signal);
+            return;
         }
         if (code !== undefined) {
             return process.exit(code);

--- a/dist/spawn.js
+++ b/dist/spawn.js
@@ -1,4 +1,5 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.spawn = void 0;
 const spawn = require("cross-spawn");
 exports.spawn = spawn;

--- a/dist/utils.js
+++ b/dist/utils.js
@@ -1,5 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.isPromise = exports.parseArgList = exports.resolveEnvFilePath = void 0;
 const path = require("path");
 const os = require("os");
 /**

--- a/src/expand-envs.ts
+++ b/src/expand-envs.ts
@@ -4,8 +4,8 @@
  * the environment variable doesn't exist, it leaves it as is.
 */
 export function expandEnvs (str: string, envs: { [key: string]: any }): string {
-  return str.replace(/(?<!\\)\$[a-zA-Z0-9_]+/g, varName => {
-    const varValue = envs[varName.slice(1)]
-    return varValue === undefined ? varName : varValue
+  return str.replace(/(?<!\\)\$\{?([a-zA-Z0-9_]+)\}?/g, (_, varName: string) => {
+    const varValue = envs[varName]
+    return varValue === undefined ? `$${varName}` : varValue
   })
 }

--- a/src/signal-termination.ts
+++ b/src/signal-termination.ts
@@ -89,7 +89,8 @@ export class TermSignals {
    */
   public _terminateProcess (code?: number, signal?: NodeJS.Signals): void {
     if (signal !== undefined) {
-      return process.kill(process.pid, signal)
+      process.kill(process.pid, signal)
+      return
     }
     if (code !== undefined) {
       return process.exit(code)

--- a/test/expand-envs.spec.ts
+++ b/test/expand-envs.spec.ts
@@ -7,12 +7,15 @@ describe('expandEnvs', (): void => {
     notvar: 'this is not used',
     dollar: 'money',
     PING: 'PONG',
-    IP1: '127.0.0.1'
+    IP1: '127.0.0.1',
+    WHO: 'World'
   }
-  const args = ['notvar', '$dollar', '\\$notvar', '-4', '$PING', '$IP1', '\\$IP1', '$NONEXIST']
-  const argsExpanded = ['notvar', 'money', '\\$notvar', '-4', 'PONG', '127.0.0.1', '\\$IP1', '$NONEXIST']
 
-  it('should replace environment variables in args', (): void => {
+  // eslint-disable-next-line no-template-curly-in-string
+  const args = ['notvar', '$dollar', '\\$notvar', '-4', '$PING', '$IP1', '\\$IP1', '$NONEXIST', '"Hello ${WHO}"']
+  const argsExpanded = ['notvar', 'money', '\\$notvar', '-4', 'PONG', '127.0.0.1', '\\$IP1', '$NONEXIST', '"Hello World"']
+
+  it.only('should replace environment variables in args', (): void => {
     const res = args.map(arg => expandEnvs(arg, envs))
     assert.sameOrderedMembers(res, argsExpanded)
   })


### PR DESCRIPTION
Adds support for parameter expansions in strings. For example:

```sh
./node_modules/.bin/env-cmd -x echo "Hello ${WHO}!"
```

and

```json
{
  "script": {
    "hello": "env-cmd -x echo \"Hello ${WHO}!\""
  }
}
```


Closes https://github.com/toddbluhm/env-cmd/issues/341