### PR TITLE
feat: adds "moustage" syntax `{{VAR}}`  variable interpolation / expand support

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,9 +62,9 @@ Options:
   -e, --environments [env1,env2,...]  The rc file environment(s) to use
   -f, --file [path]                   Custom env file path (default path: ./.env)
   --fallback                          Fallback to default env file path, if custom env file path not found
-  --no-override                       Do not override existing environment variables
+  -n, --no-override                   Do not override existing environment variables
   -r, --rc-file [path]                Custom rc file path (default path: ./.env-cmdrc(|.js|.json)
-  --silent                            Ignore any env-cmd errors and only fail on executed program failure.
+  -s, --silent                        Ignore any env-cmd errors and only fail on executed program failure.
   --use-shell                         Execute the command in a new shell with the given environment
   --verbose                           Print helpful debugging information
   -x, --expand-envs                   Replace $var in args and command with environment variables
@@ -165,6 +165,30 @@ or in `package.json` (use `\\` to insert a literal backslash)
 }
 ```
 
+### `-i` interpolate vars in arguments
+
+EnvCmd supports interpolation `{{var}}` values passed in as arguments to the command. The allows a user
+to provide arguments using "moustache" syntax to a command that are based on environment variable values at runtime.
+
+**NOTE:** Main difference between `-i` and `-x` is that you do not need to escape the `{{` & `}}` characters with `\`
+unlike using `$` in order to avoid terminal trying to auto expand it before passing it to `env-cmd`.
+
+**Terminal**
+
+```sh
+# $VAR will be expanded into the env value it contains at runtime
+./node_modules/.bin/env-cmd -x node index.js --arg={{VAR}}
+```
+
+or in `package.json`
+```json
+{
+  "script": {
+    "start": "env-cmd -x node index.js --arg={{VAR}}"
+  }
+}
+```
+
 
 ### `--silent` suppresses env-cmd errors
 
@@ -222,6 +246,7 @@ A function that executes a given command in a new child process with the given e
     - **`filePath`** { `string` }: Custom path to the `.rc` file (defaults to: `./.env-cmdrc(|.js|.json)`)
   - **`options`** { `object` }
     - **`expandEnvs`** { `boolean` }: Expand `$var` values passed to `commandArgs` (default: `false`)
+    - **`interpolateEnvs`** { `boolean` }: Interpolates `{{var}}` values passed to `commandArgs` (default: `false`)
     - **`noOverride`** { `boolean` }: Prevent `.env` file vars from overriding existing `process.env` vars (default: `false`)
     - **`silent`** { `boolean` }: Ignore any errors thrown by env-cmd, used to ignore missing file errors (default: `false`)
     - **`useShell`** { `boolean` }: Runs command inside a new shell instance (default: `false`)

--- a/dist/env-cmd.js
+++ b/dist/env-cmd.js
@@ -1,10 +1,12 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.EnvCmd = exports.CLI = void 0;
 const spawn_1 = require("./spawn");
 const signal_termination_1 = require("./signal-termination");
 const parse_args_1 = require("./parse-args");
 const get_env_vars_1 = require("./get-env-vars");
 const expand_envs_1 = require("./expand-envs");
+const interpolate_envs_1 = require("./interpolate-envs");
 /**
  * Executes env - cmd using command line arguments
  * @export
@@ -54,6 +56,10 @@ async function EnvCmd({ command, commandArgs, envFile, rc, options = {} }) {
     if (options.expandEnvs === true) {
         command = expand_envs_1.expandEnvs(command, env);
         commandArgs = commandArgs.map(arg => expand_envs_1.expandEnvs(arg, env));
+    }
+    if (options.interpolateEnvs === true) {
+        command = expand_envs_1.expandEnvs(command, env);
+        commandArgs = commandArgs.map(arg => interpolate_envs_1.interpolateEnvs(arg, env));
     }
     // Execute the command with the given environment variables
     const proc = spawn_1.spawn(command, commandArgs, {

--- a/dist/expand-envs.js
+++ b/dist/expand-envs.js
@@ -1,5 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.expandEnvs = void 0;
 /**
  * expandEnvs Replaces $var in args and command with environment variables
  * the environment variable doesn't exist, it leaves it as is.

--- a/dist/get-env-vars.js
+++ b/dist/get-env-vars.js
@@ -1,5 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.getRCFile = exports.getEnvFile = exports.getEnvVars = void 0;
 const parse_rc_file_1 = require("./parse-rc-file");
 const parse_env_file_1 = require("./parse-env-file");
 const RC_FILE_DEFAULT_LOCATIONS = ['./.env-cmdrc', './.env-cmdrc.js', './.env-cmdrc.json'];

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,8 +1,18 @@
 "use strict";
-function __export(m) {
-    for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
-}
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    Object.defineProperty(o, k2, { enumerable: true, get: function() { return m[k]; } });
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __exportStar = (this && this.__exportStar) || function(m, exports) {
+    for (var p in m) if (p !== "default" && !exports.hasOwnProperty(p)) __createBinding(exports, m, p);
+};
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.GetEnvVars = void 0;
 const get_env_vars_1 = require("./get-env-vars");
-__export(require("./env-cmd"));
+// Export the core env-cmd API
+__exportStar(require("./types"), exports);
+__exportStar(require("./env-cmd"), exports);
 exports.GetEnvVars = get_env_vars_1.getEnvVars;

--- a/dist/interpolate-envs.d.ts
+++ b/dist/interpolate-envs.d.ts
@@ -1,0 +1,7 @@
+/**
+ * interpolateEnvs Replaces {{var}} in args and command with environment variables
+ * the environment variable doesn't exist, it leaves it as is.
+*/
+export declare function interpolateEnvs(str: string, envs: {
+    [key: string]: any;
+}): string;

--- a/dist/interpolate-envs.js
+++ b/dist/interpolate-envs.js
@@ -1,0 +1,14 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.interpolateEnvs = void 0;
+/**
+ * interpolateEnvs Replaces {{var}} in args and command with environment variables
+ * the environment variable doesn't exist, it leaves it as is.
+*/
+function interpolateEnvs(str, envs) {
+    return str.replace(/(?<!\\){{[a-zA-Z0-9_]+}}/g, varName => {
+        const varValue = envs[varName.replace(/{|}/g, '')];
+        return varValue !== undefined ? varValue : varName;
+    });
+}
+exports.interpolateEnvs = interpolateEnvs;

--- a/dist/parse-args.js
+++ b/dist/parse-args.js
@@ -1,5 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.parseArgsUsingCommander = exports.parseArgs = void 0;
 const commander = require("commander");
 const utils_1 = require("./utils");
 // Use commonjs require to prevent a weird folder hierarchy in dist
@@ -29,6 +30,10 @@ function parseArgs(args) {
     let expandEnvs = false;
     if (program.expandEnvs === true) {
         expandEnvs = true;
+    }
+    let interpolate = false;
+    if (program.interpolate === true) {
+        interpolate = true;
     }
     let verbose = false;
     if (program.verbose === true) {
@@ -62,7 +67,8 @@ function parseArgs(args) {
             noOverride,
             silent,
             useShell,
-            verbose
+            verbose,
+            interpolate,
         }
     };
     if (verbose) {
@@ -79,12 +85,13 @@ function parseArgsUsingCommander(args) {
         .option('-e, --environments [env1,env2,...]', 'The rc file environment(s) to use', utils_1.parseArgList)
         .option('-f, --file [path]', 'Custom env file path (default path: ./.env)')
         .option('--fallback', 'Fallback to default env file path, if custom env file path not found')
-        .option('--no-override', 'Do not override existing environment variables')
+        .option('-n, --no-override', 'Do not override existing environment variables')
         .option('-r, --rc-file [path]', 'Custom rc file path (default path: ./.env-cmdrc(|.js|.json)')
-        .option('--silent', 'Ignore any env-cmd errors and only fail on executed program failure.')
+        .option('-s, --silent', 'Ignore any env-cmd errors and only fail on executed program failure.')
         .option('--use-shell', 'Execute the command in a new shell with the given environment')
         .option('--verbose', 'Print helpful debugging information')
         .option('-x, --expand-envs', 'Replace $var in args and command with environment variables')
+        .option('-i, --interpolate', 'Interpolates {{var}} in args and command with environment variables')
         .allowUnknownOption(true)
         .parse(['_', '_', ...args]);
 }

--- a/dist/parse-env-file.js
+++ b/dist/parse-env-file.js
@@ -1,5 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.stripEmptyLines = exports.stripComments = exports.parseEnvVars = exports.parseEnvString = exports.getEnvFileVars = void 0;
 const fs = require("fs");
 const path = require("path");
 const utils_1 = require("./utils");

--- a/dist/parse-rc-file.js
+++ b/dist/parse-rc-file.js
@@ -1,5 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.getRCFileVars = void 0;
 const fs_1 = require("fs");
 const util_1 = require("util");
 const path_1 = require("path");

--- a/dist/signal-termination.js
+++ b/dist/signal-termination.js
@@ -1,5 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.TermSignals = void 0;
 const SIGNALS_TO_HANDLE = [
     'SIGINT', 'SIGTERM', 'SIGHUP'
 ];
@@ -82,7 +83,8 @@ class TermSignals {
      */
     _terminateProcess(code, signal) {
         if (signal !== undefined) {
-            return process.kill(process.pid, signal);
+            process.kill(process.pid, signal);
+            return;
         }
         if (code !== undefined) {
             return process.exit(code);

--- a/dist/spawn.js
+++ b/dist/spawn.js
@@ -1,4 +1,5 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.spawn = void 0;
 const spawn = require("cross-spawn");
 exports.spawn = spawn;

--- a/dist/types.d.ts
+++ b/dist/types.d.ts
@@ -18,5 +18,6 @@ export interface EnvCmdOptions extends Pick<GetEnvVarOptions, 'envFile' | 'rc'> 
         silent?: boolean;
         useShell?: boolean;
         verbose?: boolean;
+        interpolateEnvs?: boolean;
     };
 }

--- a/dist/utils.js
+++ b/dist/utils.js
@@ -1,5 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.isPromise = exports.parseArgList = exports.resolveEnvFilePath = void 0;
 const path = require("path");
 const os = require("os");
 /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "env-cmd",
-  "version": "10.1.0",
+  "version": "10.2.0",
   "description": "Executes a command using the environment variables in an env file",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/env-cmd.ts
+++ b/src/env-cmd.ts
@@ -4,6 +4,7 @@ import { TermSignals } from './signal-termination'
 import { parseArgs } from './parse-args'
 import { getEnvVars } from './get-env-vars'
 import { expandEnvs } from './expand-envs'
+import { interpolateEnvs } from './interpolate-envs';
 
 /**
  * Executes env - cmd using command line arguments
@@ -60,6 +61,10 @@ export async function EnvCmd (
   if (options.expandEnvs === true) {
     command = expandEnvs(command, env)
     commandArgs = commandArgs.map(arg => expandEnvs(arg, env))
+  }
+  if (options.interpolateEnvs === true) {
+    command = expandEnvs(command, env)
+    commandArgs = commandArgs.map(arg => interpolateEnvs(arg, env))
   }
 
   // Execute the command with the given environment variables

--- a/src/env-cmd.ts
+++ b/src/env-cmd.ts
@@ -63,7 +63,7 @@ export async function EnvCmd (
     commandArgs = commandArgs.map(arg => expandEnvs(arg, env))
   }
   if (options.interpolateEnvs === true) {
-    command = expandEnvs(command, env)
+    command = interpolateEnvs(command, env)
     commandArgs = commandArgs.map(arg => interpolateEnvs(arg, env))
   }
 

--- a/src/interpolate-envs.ts
+++ b/src/interpolate-envs.ts
@@ -1,0 +1,11 @@
+
+/**
+ * interpolateEnvs Replaces {{var}} in args and command with environment variables
+ * the environment variable doesn't exist, it leaves it as is.
+*/
+export function interpolateEnvs (str: string, envs: { [key: string]: any }): string {
+  return str.replace(/(?<!\\){{[a-zA-Z0-9_]+}}/g, varName => {
+    const varValue = envs[varName.replace(/{|}/g, '')]
+    return varValue !== undefined ? varValue : varName
+  })
+}

--- a/src/parse-args.ts
+++ b/src/parse-args.ts
@@ -33,6 +33,11 @@ export function parseArgs (args: string[]): EnvCmdOptions {
   if (program.expandEnvs === true) {
     expandEnvs = true
   }
+  let interpolate = false
+  if (program.interpolate === true) {
+    interpolate = true
+  }
+
   let verbose = false
   if (program.verbose === true) {
     verbose = true
@@ -68,7 +73,8 @@ export function parseArgs (args: string[]): EnvCmdOptions {
       noOverride,
       silent,
       useShell,
-      verbose
+      verbose,
+      interpolate,
     }
   }
   if (verbose) {
@@ -85,12 +91,13 @@ export function parseArgsUsingCommander (args: string[]): commander.Command {
     .option('-e, --environments [env1,env2,...]', 'The rc file environment(s) to use', parseArgList)
     .option('-f, --file [path]', 'Custom env file path (default path: ./.env)')
     .option('--fallback', 'Fallback to default env file path, if custom env file path not found')
-    .option('--no-override', 'Do not override existing environment variables')
+    .option('-n, --no-override', 'Do not override existing environment variables')
     .option('-r, --rc-file [path]', 'Custom rc file path (default path: ./.env-cmdrc(|.js|.json)')
-    .option('--silent', 'Ignore any env-cmd errors and only fail on executed program failure.')
+    .option('-s, --silent', 'Ignore any env-cmd errors and only fail on executed program failure.')
     .option('--use-shell', 'Execute the command in a new shell with the given environment')
     .option('--verbose', 'Print helpful debugging information')
     .option('-x, --expand-envs', 'Replace $var in args and command with environment variables')
+    .option('-i, --interpolate', 'Interpolates {{var}} in args and command with environment variables')
     .allowUnknownOption(true)
     .parse(['_', '_', ...args])
 }

--- a/src/parse-args.ts
+++ b/src/parse-args.ts
@@ -33,9 +33,9 @@ export function parseArgs (args: string[]): EnvCmdOptions {
   if (program.expandEnvs === true) {
     expandEnvs = true
   }
-  let interpolate = false
+  let interpolateEnvs = false
   if (program.interpolate === true) {
-    interpolate = true
+    interpolateEnvs = true
   }
 
   let verbose = false
@@ -74,7 +74,7 @@ export function parseArgs (args: string[]): EnvCmdOptions {
       silent,
       useShell,
       verbose,
-      interpolate,
+      interpolateEnvs,
     }
   }
   if (verbose) {

--- a/src/signal-termination.ts
+++ b/src/signal-termination.ts
@@ -89,7 +89,8 @@ export class TermSignals {
    */
   public _terminateProcess (code?: number, signal?: NodeJS.Signals): void {
     if (signal !== undefined) {
-      return process.kill(process.pid, signal)
+      process.kill(process.pid, signal)
+      return
     }
     if (code !== undefined) {
       return process.exit(code)

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,6 +18,7 @@ export interface EnvCmdOptions extends Pick<GetEnvVarOptions, 'envFile' | 'rc'> 
     noOverride?: boolean
     silent?: boolean
     useShell?: boolean
-    verbose?: boolean
+    verbose?: boolean,
+    interpolateEnvs?: boolean,
   }
 }

--- a/test/env-cmd.spec.ts
+++ b/test/env-cmd.spec.ts
@@ -200,7 +200,7 @@ describe('EnvCmd', (): void => {
     async (): Promise<void> => {
       getEnvVarsStub.returns({ PING: 'PONG', CMD: 'node' })
       await envCmdLib.EnvCmd({
-        command: '$CMD',
+        command: '{{CMD}}',
         commandArgs: ['{{PING}}', '\\{{IP}}'],
         envFile: {
           filePath: './.env',

--- a/test/interpolate-envs.spec.ts
+++ b/test/interpolate-envs.spec.ts
@@ -1,0 +1,36 @@
+/* eslint @typescript-eslint/no-non-null-assertion: 0 */
+import { assert } from 'chai'
+import { interpolateEnvs } from '../src/interpolate-envs'
+
+describe('interpolateEnvs', (): void => {
+  const envs = {
+    notvar: 'this is not used',
+    dollar: 'money',
+    PING: 'PONG',
+    IP1: '127.0.0.1'
+  }
+  const args = [
+    'notvar',
+    '{{dollar}}',
+    '\\{{notvar}}',
+    '-4',
+    '{{PING}}',
+    '{{IP1}}',
+    '\\{{IP1}}',
+    '{{NONEXIST}}',
+  ]
+  const argsExpanded = [
+    'notvar',
+    'money',
+    '\\{{notvar}}',
+    '-4', 'PONG',
+    '127.0.0.1',
+    '\\{{IP1}}',
+    '{{NONEXIST}}',
+  ]
+
+  it('should interpolate environment variables in args', (): void => {
+    const res = args.map(arg => interpolateEnvs(arg, envs))
+    assert.sameOrderedMembers(res, argsExpanded)
+  })
+})

--- a/test/parse-args.spec.ts
+++ b/test/parse-args.spec.ts
@@ -98,6 +98,12 @@ describe('parseArgs', (): void => {
     assert.isTrue(res.options!.expandEnvs)
   })
 
+  it('should parse interpolateEnvs option', (): void => {
+    const res = parseArgs(['-f', envFilePath, '--interpolate', command, ...commandArgs])
+    assert.exists(res.envFile)
+    assert.isTrue(res.options!.interpolateEnvs)
+  })
+
   it('should parse silent option', (): void => {
     const res = parseArgs(['-f', envFilePath, '--silent', command, ...commandArgs])
     assert.exists(res.envFile)

--- a/test/parse-args.spec.ts
+++ b/test/parse-args.spec.ts
@@ -99,7 +99,7 @@ describe('parseArgs', (): void => {
   })
 
   it('should parse interpolateEnvs option', (): void => {
-    const res = parseArgs(['-f', envFilePath, '--interpolate', command, ...commandArgs])
+    const res = parseArgs(['-f', envFilePath, '-i', command, ...commandArgs])
     assert.exists(res.envFile)
     assert.isTrue(res.options!.interpolateEnvs)
   })


### PR DESCRIPTION
Adds "moustage" syntax variable interpolation

Closes https://github.com/toddbluhm/env-cmd/issues/343

By introducing `-i` as an alternative to `-x` to interpolate variables like `{{VAR}}`