### PR TITLE
fix: returning "true" instead of "void"

### DIFF
--- a/src/signal-termination.ts
+++ b/src/signal-termination.ts
@@ -89,10 +89,11 @@ export class TermSignals {
    */
   public _terminateProcess (code?: number, signal?: NodeJS.Signals): void {
     if (signal !== undefined) {
-      return process.kill(process.pid, signal)
+      process.kill(process.pid, signal)
+      return
     }
     if (code !== undefined) {
-      return process.exit(code)
+      process.exit(code)
     }
     throw new Error('Unable to terminate parent process successfully')
   }


### PR DESCRIPTION
Apparently process.kill() returns a Boolean, so the early return will
return a true||false rather than the void as per the func sig.

This patch ensures we return void regardless of what process.kill() and
process.exit() return. What they return may be dependent on node version
and/or platform.