### PR TITLE
fix: resolve lint issue in src/parse-rc-file.ts

### DIFF
--- a/src/get-env-vars.ts
+++ b/src/get-env-vars.ts
@@ -105,9 +105,9 @@ export async function getRCFile (
       }
       if (e.name === 'ParseError') {
         if (verbose === true) {
-            console.info(e.message);
+          console.info(e.message)
         }
-        throw new Error(e.message);
+        throw new Error(e.message)
       }
     }
   }

--- a/src/parse-rc-file.ts
+++ b/src/parse-rc-file.ts
@@ -34,7 +34,10 @@ export async function getRCFileVars (
       parsedData = JSON.parse(file)
     }
   } catch (e) {
-    const parseError = new Error(`Failed to parse .rc file at path: ${absolutePath}.\n${e.message}`)
+    const errorMessage = e instanceof Error ? e.message : 'Unknown error'
+    const parseError = new Error(
+      `Failed to parse .rc file at path: ${absolutePath}.\n${errorMessage}`
+    )
     parseError.name = 'ParseError'
     throw parseError
   }

--- a/test/parse-args.spec.ts
+++ b/test/parse-args.spec.ts
@@ -27,13 +27,13 @@ describe('parseArgs', (): void => {
   it('should parse environment value', (): void => {
     const res = parseArgs(['-e', environments[0], command])
     assert.exists(res.rc)
-    assert.sameOrderedMembers(res.rc!.environments, [environments[0]])
+    assert.sameOrderedMembers(res.rc.environments, [environments[0]])
   })
 
   it('should parse multiple environment values', (): void => {
     const res = parseArgs(['-e', environments.join(','), command])
     assert.exists(res.rc)
-    assert.sameOrderedMembers(res.rc!.environments, environments)
+    assert.sameOrderedMembers(res.rc.environments, environments)
   })
 
   it('should parse command value', (): void => {
@@ -59,31 +59,31 @@ describe('parseArgs', (): void => {
   it('should parse override option', (): void => {
     const res = parseArgs(['-e', environments[0], '--no-override', command, ...commandArgs])
     assert.exists(res.options)
-    assert.isTrue(res.options!.noOverride)
+    assert.isTrue(res.options.noOverride)
   })
 
   it('should parse use shell option', (): void => {
     const res = parseArgs(['-e', environments[0], '--use-shell', command, ...commandArgs])
     assert.exists(res.options)
-    assert.isTrue(res.options!.useShell)
+    assert.isTrue(res.options.useShell)
   })
 
   it('should parse rc file path', (): void => {
     const res = parseArgs(['-e', environments[0], '-r', rcFilePath, command, ...commandArgs])
     assert.exists(res.rc)
-    assert.equal(res.rc!.filePath, rcFilePath)
+    assert.equal(res.rc.filePath, rcFilePath)
   })
 
   it('should parse env file path', (): void => {
     const res = parseArgs(['-f', envFilePath, command, ...commandArgs])
     assert.exists(res.envFile)
-    assert.equal(res.envFile!.filePath, envFilePath)
+    assert.equal(res.envFile.filePath, envFilePath)
   })
 
   it('should parse fallback option', (): void => {
     const res = parseArgs(['-f', envFilePath, '--fallback', command, ...commandArgs])
     assert.exists(res.envFile)
-    assert.isTrue(res.envFile!.fallback)
+    assert.isTrue(res.envFile.fallback)
   })
 
   it('should print to console.info if --verbose flag is passed', (): void => {


### PR DESCRIPTION
Tests currently aren't running on CI because lint is failing. This corrects linting errors in src/parse-rc-file.ts to ensure compliance with code style guidelines. It also resolves other auto-fixable lint errors.