### PR TITLE
fix(parse-env-file): fix strip comments per PR #333

### DIFF
--- a/dist/parse-env-file.js
+++ b/dist/parse-env-file.js
@@ -85,14 +85,8 @@ export function parseEnvVars(envString) {
  * Strips out comments from env file string
  */
 export function stripComments(envString) {
-    const commentsRegex = /(^#.*$)/gim;
-    let match = commentsRegex.exec(envString);
-    let newString = envString;
-    while (match != null) {
-        newString = newString.replace(match[1], '');
-        match = commentsRegex.exec(envString);
-    }
-    return newString;
+    const commentsRegex = /(^\s*#.*$)/gim;
+    return envString.replace(commentsRegex, '');
 }
 /**
  * Strips out newlines from env file string

--- a/src/parse-env-file.ts
+++ b/src/parse-env-file.ts
@@ -94,14 +94,8 @@ export function parseEnvVars(envString: string): Environment {
  * Strips out comments from env file string
  */
 export function stripComments(envString: string): string {
-  const commentsRegex = /(^#.*$)/gim
-  let match = commentsRegex.exec(envString)
-  let newString = envString
-  while (match != null) {
-    newString = newString.replace(match[1], '')
-    match = commentsRegex.exec(envString)
-  }
-  return newString
+  const commentsRegex = /(^\s*#.*$)/gim
+  return envString.replace(commentsRegex, '')
 }
 
 /**

--- a/test/parse-env-file.spec.ts
+++ b/test/parse-env-file.spec.ts
@@ -16,6 +16,11 @@ describe('stripComments', (): void => {
     const envString = stripComments('#BOB=COOL\nNODE_ENV=dev\nANSWER=42 AND COUNTING\n#AnotherComment\n')
     assert(envString === '\nNODE_ENV=dev\nANSWER=42 AND COUNTING\n\n')
   })
+
+  it('should not strip out #s from values', (): void => {
+    const envString = stripComments('#\nBOB=COMMENT#ELL\n#\nNODE_ENV=dev\nANSWER=42 AND COUNTING\n#AnotherComment\n')
+    assert(envString === '\nBOB=COMMENT#ELL\n\nNODE_ENV=dev\nANSWER=42 AND COUNTING\n\n', envString)
+  })
 })
 
 describe('parseEnvVars', (): void => {


### PR DESCRIPTION
From #333, this updates and replaces that PR

> If you have a value containing a # followed at some point by a line containing only #\n, the wrong # will be removed by stripComments().

>This PR both fixes this issue and simplifies stripComments().