### PR TITLE
fix(*): fix crash on node v18.0 caused by Import Attribute syntax

### DIFF
--- a/dist/parse-args.js
+++ b/dist/parse-args.js
@@ -1,6 +1,9 @@
+import { createRequire } from 'node:module';
 import { Command } from '@commander-js/extra-typings';
 import { parseArgList } from './utils.js';
-import { default as packageJson } from '../package.json' with { type: 'json' };
+// TODO: once we drop support for node <v20.10, this can be converted to
+// a normal import statement
+const packageJson = createRequire(import.meta.url)('../package.json');
 /**
 * Parses the arguments passed into the cli
 */

--- a/dist/parse-env-file.js
+++ b/dist/parse-env-file.js
@@ -1,7 +1,7 @@
 import { existsSync, readFileSync } from 'node:fs';
 import { extname } from 'node:path';
 import { pathToFileURL } from 'node:url';
-import { resolveEnvFilePath, IMPORT_HOOK_EXTENSIONS, isPromise } from './utils.js';
+import { resolveEnvFilePath, IMPORT_HOOK_EXTENSIONS, isPromise, importAttributesKeyword } from './utils.js';
 /**
  * Gets the environment vars from an env file
  */
@@ -19,7 +19,7 @@ export async function getEnvFileVars(envFilePath) {
         // For some reason in ES Modules, only JSON file types need to be specifically delinated when importing them
         let attributeTypes = {};
         if (ext === '.json') {
-            attributeTypes = { with: { type: 'json' } };
+            attributeTypes = { [importAttributesKeyword]: { type: 'json' } };
         }
         const res = await import(pathToFileURL(absolutePath).href, attributeTypes);
         if ('default' in res) {

--- a/dist/parse-rc-file.js
+++ b/dist/parse-rc-file.js
@@ -2,7 +2,7 @@ import { stat, readFile } from 'node:fs';
 import { promisify } from 'node:util';
 import { extname } from 'node:path';
 import { pathToFileURL } from 'node:url';
-import { resolveEnvFilePath, IMPORT_HOOK_EXTENSIONS, isPromise } from './utils.js';
+import { resolveEnvFilePath, IMPORT_HOOK_EXTENSIONS, isPromise, importAttributesKeyword } from './utils.js';
 const statAsync = promisify(stat);
 const readFileAsync = promisify(readFile);
 /**
@@ -26,7 +26,7 @@ export async function getRCFileVars({ environments, filePath }) {
             // For some reason in ES Modules, only JSON file types need to be specifically delinated when importing them
             let attributeTypes = {};
             if (ext === '.json') {
-                attributeTypes = { with: { type: 'json' } };
+                attributeTypes = { [importAttributesKeyword]: { type: 'json' } };
             }
             const res = await import(pathToFileURL(absolutePath).href, attributeTypes);
             if ('default' in res) {

--- a/dist/utils.d.ts
+++ b/dist/utils.d.ts
@@ -11,3 +11,4 @@ export declare function parseArgList(list: string): string[];
  * A simple function to test if the value is a promise/thenable
  */
 export declare function isPromise<T>(value?: T | PromiseLike<T>): value is PromiseLike<T>;
+export declare const importAttributesKeyword: string;

--- a/dist/utils.js
+++ b/dist/utils.js
@@ -29,3 +29,9 @@ export function isPromise(value) {
         && 'then' in value
         && typeof value.then === 'function';
 }
+// "Import Attributes" are only supported since node v18.20 and v20.10.
+// For older node versions, we have to use "Import Assertions".
+// TODO: remove this check when we drop support for node v20
+const [major, minor] = process.version.slice(1).split('.').map(Number);
+const legacyImportAssertions = (major === 18 && minor < 20) || (major === 20 && minor < 10);
+export const importAttributesKeyword = legacyImportAssertions ? 'assert' : 'with';

--- a/src/parse-args.ts
+++ b/src/parse-args.ts
@@ -1,7 +1,13 @@
+import { createRequire } from 'node:module'
 import { Command } from '@commander-js/extra-typings'
 import type { EnvCmdOptions, CommanderOptions, EnvFileOptions, RCFileOptions } from './types.ts'
 import { parseArgList } from './utils.js'
-import { default as packageJson } from '../package.json' with { type: 'json' }; 
+
+// TODO: once we drop support for node <v20.10, this can be converted to
+// a normal import statement
+const packageJson = createRequire(import.meta.url)('../package.json') as {
+  version: string;
+}
 
 /**
 * Parses the arguments passed into the cli

--- a/src/parse-env-file.ts
+++ b/src/parse-env-file.ts
@@ -1,7 +1,7 @@
 import { existsSync, readFileSync } from 'node:fs'
 import { extname } from 'node:path'
 import { pathToFileURL } from 'node:url'
-import { resolveEnvFilePath, IMPORT_HOOK_EXTENSIONS, isPromise } from './utils.js'
+import { resolveEnvFilePath, IMPORT_HOOK_EXTENSIONS, isPromise, importAttributesKeyword } from './utils.js'
 import type { Environment } from './types.ts'
 
 /**
@@ -22,7 +22,7 @@ export async function getEnvFileVars(envFilePath: string): Promise<Environment> 
     // For some reason in ES Modules, only JSON file types need to be specifically delinated when importing them
     let attributeTypes = {}
     if (ext === '.json') {
-      attributeTypes = { with: { type: 'json' } }
+      attributeTypes = { [importAttributesKeyword]: { type: 'json' } }
     }
     const res = await import(pathToFileURL(absolutePath).href, attributeTypes) as Environment | { default: Environment }
     if ('default' in res) {

--- a/src/parse-rc-file.ts
+++ b/src/parse-rc-file.ts
@@ -2,7 +2,7 @@ import { stat, readFile } from 'node:fs'
 import { promisify } from 'node:util'
 import { extname } from 'node:path'
 import { pathToFileURL } from 'node:url'
-import { resolveEnvFilePath, IMPORT_HOOK_EXTENSIONS, isPromise } from './utils.js'
+import { resolveEnvFilePath, IMPORT_HOOK_EXTENSIONS, isPromise, importAttributesKeyword } from './utils.js'
 import type { Environment, RCEnvironment } from './types.ts'
 
 const statAsync = promisify(stat)
@@ -33,7 +33,7 @@ export async function getRCFileVars(
       // For some reason in ES Modules, only JSON file types need to be specifically delinated when importing them
       let attributeTypes = {}
       if (ext === '.json') {
-        attributeTypes = { with: { type: 'json' } }
+        attributeTypes = { [importAttributesKeyword]: { type: 'json' } }
       }
       const res = await import(pathToFileURL(absolutePath).href, attributeTypes) as RCEnvironment | { default: RCEnvironment }
       if ('default' in res) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -32,3 +32,13 @@ export function isPromise<T>(value?: T | PromiseLike<T>): value is PromiseLike<T
     && 'then' in value
     && typeof value.then === 'function'
 }
+
+
+// "Import Attributes" are only supported since node v18.20 and v20.10.
+// For older node versions, we have to use "Import Assertions".
+// TODO: remove this check when we drop support for node v20
+const [major, minor] = process.version.slice(1).split('.').map(Number)
+const legacyImportAssertions =
+  (major === 18 && minor < 20) || (major === 20 && minor < 10)
+
+export const importAttributesKeyword = legacyImportAssertions ? 'assert' : 'with'


### PR DESCRIPTION
The latest refactoring (#392) caused this library to crash for node versions `v18.0`-`v18.19` and `20.0`-`20.9`.

These versions of node don't support "[Import Attributes](https://v8.dev/features/import-attributes)" (`import ...  from ... with ...`), they only support "[Import Assertions](https://v8.dev/features/import-assertions)" (`import ...  from ... assert ...`).

---

In a follow-up PR I'll update the test suite to run the oldest version of node that we support (v18.0.0). This is non-straightforward because [esmock](https://npm.im/esmock) doesn't work well on this version of node