### PR TITLE
feat(cli): provide a more helpful error if there's no command

### DIFF
--- a/src/env-cmd.ts
+++ b/src/env-cmd.ts
@@ -45,6 +45,13 @@ export async function EnvCmd(
     commandArgs = commandArgs.map(arg => expandEnvs(arg, env))
   }
 
+  if (!command) {
+    throw new Error(
+      'env-cmd cannot be used as a standalone command. ' +
+        'Refer to the documentation for usage examples: https://npm.im/env-cmd',
+    );
+  }
+
   // Execute the command with the given environment variables
   const proc = spawn(command, commandArgs, {
     stdio: 'inherit',

--- a/test/env-cmd.spec.ts
+++ b/test/env-cmd.spec.ts
@@ -209,4 +209,22 @@ describe('EnvCmd', (): void => {
       assert.fail('Should not get here.')
     },
   )
+
+  it('provides a helpful error if the CLI is incorrectly invoked', async () => {
+    getEnvVarsStub.returns({ BOB: 'test' });
+    try {
+      await envCmdLib.EnvCmd({
+        command: '',
+        commandArgs: [],
+        envFile: {
+          filePath: './.env',
+        },
+      });
+    } catch (e) {
+      assert.instanceOf(e, Error);
+      assert.include(e.message, 'cannot be used as a standalone');
+      return;
+    }
+    assert.fail('Should not get here.');
+  });
 })


### PR DESCRIPTION
Closes #149, Closes #134, Closes #283

There is now a helpful error if you run `env-cmd` on its own, without any associated command. (for example: `env-cmd && node ....`)

The current error is "[ERR_INVALID_ARG_TYPE](https://github.com/toddbluhm/env-cmd/issues/149)" which is quite cryptic