### PR TITLE
feat: parse inline comments

### DIFF
--- a/src/parse-env-file.ts
+++ b/src/parse-env-file.ts
@@ -66,12 +66,19 @@ export function parseEnvVars(envString: string): Environment {
   while ((match = envParseRegex.exec(envString)) !== null) {
     // Note: match[1] is the full env=var line
     const key = match[2].trim()
-    let value: string | number | boolean = match[3].trim()
+    let value = match[3].trim()
 
-    // remove any surrounding quotes
-    value = value
-      .replace(/(^['"]|['"]$)/g, '')
-      .replace(/\\n/g, '\n')
+    // if the string is quoted, remove everything after the final
+    // quote. This implicitly removes inline comments.
+    if (value.startsWith("'") || value.startsWith('"')) {
+      value = value.slice(1, value.lastIndexOf(value[0]));
+    } else {
+      // if the string is not quoted, we need to explicitly remove
+      // inline comments.
+      value = value.split('#')[0].trim();
+    }
+  
+    value = value.replace(/\\n/g, '\n');
 
     // Convert string to JS type if appropriate
     if (value !== '' && !isNaN(+value)) {

--- a/test/parse-env-file.spec.ts
+++ b/test/parse-env-file.spec.ts
@@ -96,6 +96,36 @@ describe('parseEnvVars', (): void => {
     assert(envVars.NODE_ENV === 'dev')
     assert(envVars.ANSWER === ' 42 AND COUNTING')
   })
+
+  describe('value', () => {
+    const testCases = [
+      [`a`, `a`],
+      [`'a'`, `a`],
+      [`"a"`, `a`],
+      [`"a"`, `a`],
+      [`"single 'quotes' inside double"`, `single 'quotes' inside double`],
+      [`'double "quotes" inside single'`, `double "quotes" inside single`],
+      [`a # comment without quotes`, `a`],
+      [`'a' # comment with single quotes`, `a`],
+      [`"a" # comment with double quotes`, `a`],
+      [`"a"garbage after final quote`, `a`],
+      [
+        `"double quotes " within double quotes"`,
+        `double quotes " within double quotes`,
+      ],
+      [
+        `'single quotes ' within single quotes'`,
+        `single quotes ' within single quotes`,
+      ],
+      [`line\\nbreaks`, `line\nbreaks`],
+      [`"line\\n\\nbreaks in quotes"`, `line\n\nbreaks in quotes`],
+    ];
+    for (const [input, output] of testCases) {
+      it(`should parse ${input}`, () => {
+        assert.equal(parseEnvVars(`KEY=${input}`).KEY, output)
+      })
+    }
+  })
 })
 
 describe('parseEnvString', (): void => {
@@ -172,6 +202,14 @@ describe('getEnvFileVars', (): void => {
       ONLY: 'IN=PRODUCTION',
       GALAXY: 'hitch\nhiking',
       BRINGATOWEL: true,
+      a: 1,
+      b: 2,
+      c: 3,
+      d: "=",
+      e: "equals symbol = = ",
+      json_no_quotes: "{\"foo\": \"bar\"}",
+      json_with_quotes: "{\"foo\": \"bar\"}",
+      quotes: "hello \n\n \" 'escaped \\tsingle quote' \" #cool #fun ",
     })
   })
 

--- a/test/test-files/test
+++ b/test/test-files/test
@@ -3,3 +3,14 @@ ANSWER=42
 ONLY= "IN=PRODUCTION"
 GALAXY="hitch\nhiking"
 BRINGATOWEL=true
+# full-line comment
+#
+quotes = 'hello \n\n " 'escaped \tsingle quote' " #cool #fun ' # inline comment
+a=1#inline comment
+b='2'#inline comment
+c="3"#inline comment
+d==
+e='equals symbol = = '
+json_no_quotes={"foo": "bar"}
+json_with_quotes='{"foo": "bar"}'
+json_with_quotes='{"foo": "bar"}'


### PR DESCRIPTION
Closes #272

Because of #393, the next release will already be a potential breaking change for `.env.*` files that include a `#` symbol on the same line as key/value pair.

So, this might be a good opportunity to resolve another long-standing inconsistency between this repository and other `.env` tools. Specifically: **inline comment support**.

Tools/libraries that support inline comments in `.env` files:
 - [dotenv](https://github.com/motdotla/dotenv/pull/568)
 - [phpdotenv](https://github.com/vlucas/phpdotenv#comments)
 - [dotenvx](https://github.com/dotenvx/dotenvx)
 - [the unofficial spec](https://hexdocs.pm/dotenvy/dotenv-file-format.html#comments)
 - [GitHub.com's default syntax highlighting](https://github.com/github-linguist/linguist/blob/5fad8d57605a914026a65b0e3ff6815d739944de/lib/linguist/languages.yml#L1651)
 - [VS Code's default syntax highlighting](https://github.com/user-attachments/assets/a3aca282-6c72-4edd-b371-020bde0174b0)

Tools/library that do not support inline comments:
- env-cmd
- _others?_



