### PR TITLE
chore: fix CI failing on the master branch

### DIFF
--- a/dist/expand-envs.js
+++ b/dist/expand-envs.js
@@ -6,6 +6,6 @@ export function expandEnvs(str, envs) {
     return str.replace(/(?<!\\)\$[a-zA-Z0-9_]+/g, (varName) => {
         const varValue = envs[varName.slice(1)];
         // const test = 42;
-        return varValue === undefined ? varName : varValue.toString();
+        return varValue ?? varName;
     });
 }

--- a/dist/parse-env-file.js
+++ b/dist/parse-env-file.js
@@ -49,7 +49,7 @@ export async function getEnvFileVars(envFilePath) {
  */
 export function parseEnvString(envFileString) {
     // First thing we do is stripe out all comments
-    envFileString = stripComments(envFileString.toString());
+    envFileString = stripComments(envFileString);
     // Next we stripe out all the empty lines
     envFileString = stripEmptyLines(envFileString);
     // Merge the file env vars with the current process env vars (the file vars overwrite process vars)
@@ -110,7 +110,7 @@ export function normalizeEnvObject(input, absolutePath) {
     const env = {};
     for (const [key, value] of Object.entries(input)) {
         // we're intentionally stringifying the value here, to
-        // match what `child_process.spawn` does when loading 
+        // match what `child_process.spawn` does when loading
         // env variables.
         // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
         env[key] = `${value}`;

--- a/src/expand-envs.ts
+++ b/src/expand-envs.ts
@@ -8,6 +8,6 @@ export function expandEnvs(str: string, envs: Environment): string {
   return str.replace(/(?<!\\)\$[a-zA-Z0-9_]+/g, (varName) => {
     const varValue = envs[varName.slice(1)]
     // const test = 42;
-    return varValue === undefined ? varName : varValue.toString()
+    return varValue ?? varName
   })
 }

--- a/src/parse-env-file.ts
+++ b/src/parse-env-file.ts
@@ -56,7 +56,7 @@ export async function getEnvFileVars(envFilePath: string): Promise<Environment> 
  */
 export function parseEnvString(envFileString: string): Environment {
   // First thing we do is stripe out all comments
-  envFileString = stripComments(envFileString.toString())
+  envFileString = stripComments(envFileString)
 
   // Next we stripe out all the empty lines
   envFileString = stripEmptyLines(envFileString)
@@ -126,7 +126,7 @@ export function normalizeEnvObject(input: unknown, absolutePath: string): Enviro
   const env: Environment = {};
   for (const [key, value] of Object.entries(input)) {
     // we're intentionally stringifying the value here, to
-    // match what `child_process.spawn` does when loading 
+    // match what `child_process.spawn` does when loading
     // env variables.
     // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
     env[key] = `${value}`


### PR DESCRIPTION
we don't use a [lockfile](https://docs.npmjs.com/cli/v7/configuring-npm/package-lock-json) in this repository (see 727f429 ), so the CI could start failing despite nothing changing in this repo.

The current failures are because this line:

https://github.com/toddbluhm/env-cmd/blob/adf1934f01074ec2a97b5f975d439faef99c96a2/package.json#L76


...now resolves to `v8.39.0`, and one of the recent updates in that package included breaking changes