### PR TITLE
Fix failing test case

### DIFF
--- a/test/parse-env-file.spec.ts
+++ b/test/parse-env-file.spec.ts
@@ -194,7 +194,7 @@ describe('getEnvFileVars', (): void => {
     })
   });
 
-  (process.features.typescript ? describe : describe.skip)('TS', () => {
+  (process.features.typescript === 'transform' ? describe : describe.skip)('TS', () => {
     it('should parse a .ts file', async () => {
       const env = await getEnvFileVars('./test/test-files/ts-test.ts');
       assert.deepEqual(env, {


### PR DESCRIPTION
Fix the failing test cases due to node version changes. Seems like `process.feature.typescript` is now defined by default on most modern versions, need to check for specific enablement